### PR TITLE
Fix `no-empty-pattern` rule

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -8,6 +8,7 @@ module.exports = {
         "shared-node-browser": true,
       },
       rules: {
+        "no-empty-pattern": "off",
         "playwright/missing-playwright-await": "error",
       },
     },
@@ -45,6 +46,5 @@ module.exports = {
   },
   rules: {
     "missing-playwright-await": missingPlaywrightAwait,
-    "no-empty-pattern": "off",
   },
 };


### PR DESCRIPTION
The `no-empty-pattern` rule was added to the wrong section of the plugin config.