### PR TITLE
Add new "no element handle" rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,9 +100,9 @@ await page.click('button');
 
 ### `no-element-handle`
 
-Disallow the use of `page.$` or `page.$$` element handle.
+Disallow the creation of element handles with `page.$` or `page.$$`.
 
-👎 Examples of <span style="color:red">**incorrect**</span> code for this rule:
+Examples of **incorrect** code for this rule:
 
 ```js
 // Element Handle
@@ -113,7 +113,7 @@ await buttonHandle.click();
 const linkHandles = await page.$$('a');
 ```
 
-👍 Example of <span style="color:green">**correct**</span> code for this rule:
+Example of **correct** code for this rule:
 
 ```js
 const buttonLocator = page.locator('button');

--- a/README.md
+++ b/README.md
@@ -98,3 +98,24 @@ Example of **correct** code for this rule:
 await page.click('button');
 ```
 
+### `no-element-handle`
+
+Disallow the use of `page.$` or `page.$$` element handle.
+
+👎 Examples of <span style="color:red">**incorrect**</span> code for this rule:
+
+```js
+// Element Handle
+const buttonHandle = await page.$('button');
+await buttonHandle.click();
+
+// Element Handles
+const linkHandles = await page.$$('a');
+```
+
+👍 Example of <span style="color:green">**correct**</span> code for this rule:
+
+```js
+const buttonLocator = page.locator('button');
+await buttonLocator.click();
+```

--- a/lib/index.js
+++ b/lib/index.js
@@ -13,7 +13,7 @@ module.exports = {
         "no-empty-pattern": "off",
         "playwright/missing-playwright-await": "error",
         "playwright/no-page-pause": "warn",
-        "playwright/no-element-handle": "error",
+        "playwright/no-element-handle": "warn",
       },
     },
     "jest-playwright": {

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,5 +1,6 @@
 const missingPlaywrightAwait = require("./rules/missing-playwright-await");
 const noPagePause = require("./rules/no-page-pause");
+const noElementHandle = require("./rules/no-element-handle");
 
 module.exports = {
   configs: {
@@ -12,6 +13,7 @@ module.exports = {
         "no-empty-pattern": "off",
         "playwright/missing-playwright-await": "error",
         "playwright/no-page-pause": "warn",
+        "playwright/no-element-handle": "error",
       },
     },
     "jest-playwright": {
@@ -50,5 +52,6 @@ module.exports = {
   rules: {
     "missing-playwright-await": missingPlaywrightAwait,
     "no-page-pause": noPagePause,
+    "no-element-handle": noElementHandle
   },
 };

--- a/lib/rules/no-element-handle.js
+++ b/lib/rules/no-element-handle.js
@@ -1,0 +1,64 @@
+function isPageIdentifier(node) {
+  return (
+    node.callee &&
+    node.callee.type === 'MemberExpression' &&
+    node.callee.object.type === 'Identifier' &&
+    node.callee.object.name === 'page'
+  );
+}
+
+function isElementHandleIdentifier(node) {
+  return (
+    node.callee &&
+    node.callee.property &&
+    node.callee.property.type === 'Identifier' &&
+    node.callee.property.name === '$'
+  );
+}
+
+function isElementHandlesIdentifier(node) {
+  return (
+    node.callee &&
+    node.callee.property &&
+    node.callee.property.type === 'Identifier' &&
+    node.callee.property.name === '$$'
+  );
+}
+
+function getRange(node) {
+  if (node.parent && node.parent.type === 'AwaitExpression') {
+    const [start] = node.parent.range;
+    const end = isElementHandleIdentifier(node) ? start + 'await page.$'.length : start + 'await page.$$'.length;
+
+    return [start, end];
+  }
+}
+
+module.exports = {
+  create(context) {
+    return {
+      CallExpression(node) {
+        if (isPageIdentifier(node) && (isElementHandleIdentifier(node) || isElementHandlesIdentifier(node))) {
+          context.report({
+            messageId: 'noElementHandle',
+            fix: (fixer) => fixer.replaceTextRange(getRange(node), 'page.locator'),
+            node,
+          });
+        }
+      },
+    };
+  },
+  meta: {
+    docs: {
+      category: 'Possible Errors',
+      description: 'The use of ElementHandle is discouraged, use Locator instead',
+      recommended: true,
+      url: 'https://github.com/playwright-community/eslint-plugin-playwright#no-element-handle',
+    },
+    fixable: 'code',
+    messages: {
+      noElementHandle: 'disallow the use of `page.$` or `page.$$` element handle',
+    },
+    type: 'problem',
+  },
+};

--- a/lib/rules/no-element-handle.js
+++ b/lib/rules/no-element-handle.js
@@ -56,7 +56,9 @@ module.exports = {
             messageId: 'noElementHandle',
             suggest: [
               {
-                messageId: 'replaceWithLocator',
+                messageId: isElementHandleIdentifier(node)
+                  ? 'replaceElementHandleWithLocator'
+                  : 'replaceElementHandlesWithLocator',
                 fix: (fixer) => fixer.replaceTextRange(getRange(node), 'page.locator'),
               },
             ],
@@ -76,7 +78,8 @@ module.exports = {
     hasSuggestions: true,
     messages: {
       noElementHandle: 'Unexpected use of element handles.',
-      replaceWithLocator: 'Replace `page.$` and `page.$$` with `page.locator`',
+      replaceElementHandleWithLocator: 'Replace `page.$` with `page.locator`',
+      replaceElementHandlesWithLocator: 'Replace `page.$$` with `page.locator`',
     },
     type: 'suggestion',
   },

--- a/lib/rules/no-element-handle.js
+++ b/lib/rules/no-element-handle.js
@@ -54,7 +54,12 @@ module.exports = {
         if (isPageIdentifier(node) && (isElementHandleIdentifier(node) || isElementHandlesIdentifier(node))) {
           context.report({
             messageId: 'noElementHandle',
-            fix: (fixer) => fixer.replaceTextRange(getRange(node), 'page.locator'),
+            suggest: [
+              {
+                messageId: 'replaceWithLocator',
+                fix: (fixer) => fixer.replaceTextRange(getRange(node), 'page.locator'),
+              },
+            ],
             node,
           });
         }
@@ -68,9 +73,10 @@ module.exports = {
       recommended: true,
       url: 'https://github.com/playwright-community/eslint-plugin-playwright#no-element-handle',
     },
-    fixable: 'code',
+    hasSuggestions: true,
     messages: {
       noElementHandle: 'Unexpected use of element handles.',
+      replaceWithLocator: 'Replace `page.$` and `page.$$` with `page.locator`',
     },
     type: 'problem',
   },

--- a/lib/rules/no-element-handle.js
+++ b/lib/rules/no-element-handle.js
@@ -70,7 +70,7 @@ module.exports = {
     },
     fixable: 'code',
     messages: {
-      noElementHandle: 'disallow the use of `page.$` or `page.$$` element handle',
+      noElementHandle: 'Unexpected use of element handles.',
     },
     type: 'problem',
   },

--- a/lib/rules/no-element-handle.js
+++ b/lib/rules/no-element-handle.js
@@ -78,6 +78,6 @@ module.exports = {
       noElementHandle: 'Unexpected use of element handles.',
       replaceWithLocator: 'Replace `page.$` and `page.$$` with `page.locator`',
     },
-    type: 'problem',
+    type: 'suggestion',
   },
 };

--- a/lib/rules/no-element-handle.js
+++ b/lib/rules/no-element-handle.js
@@ -26,14 +26,25 @@ function isElementHandlesIdentifier(node) {
 }
 
 function getRange(node) {
-  if (node.parent && node.parent.type === 'AwaitExpression') {
-    const [start] = node.parent.range;
-    const elementHandleEnd = start + 'await page.$'.length;
-    const elementHandlesEnd = start + 'await page.$$'.length;
-    const end = isElementHandleIdentifier(node) ? elementHandleEnd : elementHandlesEnd;
+  const awaitLength = 'await '.length;
+  const elementHandleLength = 'page.$'.length;
+  const elementHandlesLength = 'page.$$'.length;
 
-    return [start, end];
+  let start = 0;
+  let end = 0;
+
+  if (node.parent && node.parent.type === 'AwaitExpression') {
+    start = start + node.parent.range[0];
+    end = start + awaitLength;
+  } else {
+    start = start + node.range[0];
+    end += start;
   }
+
+  if (isElementHandleIdentifier(node)) end += elementHandleLength;
+  if (isElementHandlesIdentifier(node)) end += elementHandlesLength;
+
+  return [start, end];
 }
 
 module.exports = {

--- a/lib/rules/no-element-handle.js
+++ b/lib/rules/no-element-handle.js
@@ -1,27 +1,27 @@
-function isPageIdentifier(node) {
+function isPageIdentifier({ callee }) {
   return (
-    node.callee &&
-    node.callee.type === 'MemberExpression' &&
-    node.callee.object.type === 'Identifier' &&
-    node.callee.object.name === 'page'
+    callee &&
+    callee.type === 'MemberExpression' &&
+    callee.object.type === 'Identifier' &&
+    callee.object.name === 'page'
   );
 }
 
-function isElementHandleIdentifier(node) {
+function isElementHandleIdentifier({ callee }) {
   return (
-    node.callee &&
-    node.callee.property &&
-    node.callee.property.type === 'Identifier' &&
-    node.callee.property.name === '$'
+    callee &&
+    callee.property &&
+    callee.property.type === 'Identifier' &&
+    callee.property.name === '$'
   );
 }
 
-function isElementHandlesIdentifier(node) {
+function isElementHandlesIdentifier({ callee }) {
   return (
-    node.callee &&
-    node.callee.property &&
-    node.callee.property.type === 'Identifier' &&
-    node.callee.property.name === '$$'
+    callee &&
+    callee.property &&
+    callee.property.type === 'Identifier' &&
+    callee.property.name === '$$'
   );
 }
 

--- a/lib/rules/no-element-handle.js
+++ b/lib/rules/no-element-handle.js
@@ -28,7 +28,9 @@ function isElementHandlesIdentifier(node) {
 function getRange(node) {
   if (node.parent && node.parent.type === 'AwaitExpression') {
     const [start] = node.parent.range;
-    const end = isElementHandleIdentifier(node) ? start + 'await page.$'.length : start + 'await page.$$'.length;
+    const elementHandleEnd = start + 'await page.$'.length;
+    const elementHandlesEnd = start + 'await page.$$'.length;
+    const end = isElementHandleIdentifier(node) ? elementHandleEnd : elementHandlesEnd;
 
     return [start, end];
   }

--- a/lib/rules/no-element-handle.js
+++ b/lib/rules/no-element-handle.js
@@ -26,25 +26,11 @@ function isElementHandlesIdentifier({ callee }) {
 }
 
 function getRange(node) {
-  const awaitLength = 'await '.length;
-  const elementHandleLength = 'page.$'.length;
-  const elementHandlesLength = 'page.$$'.length;
+  const start = node.parent && node.parent.type === 'AwaitExpression' 
+    ? node.parent.range[0]
+    : node.callee.object.range[0];
 
-  let start = 0;
-  let end = 0;
-
-  if (node.parent && node.parent.type === 'AwaitExpression') {
-    start = start + node.parent.range[0];
-    end = start + awaitLength;
-  } else {
-    start = start + node.range[0];
-    end += start;
-  }
-
-  if (isElementHandleIdentifier(node)) end += elementHandleLength;
-  if (isElementHandlesIdentifier(node)) end += elementHandlesLength;
-
-  return [start, end];
+  return [start, node.callee.property.range[1]];
 }
 
 module.exports = {

--- a/test/no-element-handle.spec.js
+++ b/test/no-element-handle.spec.js
@@ -11,8 +11,12 @@ const wrapInTest = (input) => `test('verify noElementHandle rule', async () => {
 
 const invalid = (code, output) => ({
   code: wrapInTest(code),
-  errors: [{ messageId: 'noElementHandle' }],
-  output: wrapInTest(output),
+  errors: [
+    {
+      messageId: 'noElementHandle',
+      suggestions: [{ messageId: 'replaceWithLocator', output: wrapInTest(output) }],
+    },
+  ],
 });
 
 const valid = (code) => ({
@@ -22,10 +26,16 @@ const valid = (code) => ({
 new RuleTester().run('no-element-handle', rule, {
   invalid: [
     // element handle as const
-    invalid("const handle = await page.$('text=Submit');", "const handle = page.locator('text=Submit');"),
+    invalid('const handle = await page.$("text=Submit");', 'const handle = page.locator("text=Submit");'),
 
     // element handle as let
-    invalid("let handle = await page.$('text=Submit');", "let handle = page.locator('text=Submit');"),
+    invalid('let handle = await page.$("text=Submit");', 'let handle = page.locator("text=Submit");'),
+
+    // element handle as expression statement without await
+    invalid('page.$("div")', 'page.locator("div")'),
+
+    // element handles as expression statement without await
+    invalid('page.$$("div")', 'page.locator("div")'),
 
     // element handle as expression statement
     invalid('await page.$("div")', 'page.locator("div")'),
@@ -55,10 +65,7 @@ new RuleTester().run('no-element-handle', rule, {
     ),
 
     // missed return for the element handle
-    invalid(
-      'function getHandle() { page.$("button"); }',
-      'function getHandle() { page.locator("button"); }'
-    ),
+    invalid('function getHandle() { page.$("button"); }', 'function getHandle() { page.locator("button"); }'),
 
     // arrow function return element handle without awaiting it
     invalid('const getHandles = () => page.$("links");', 'const getHandles = () => page.locator("links");'),

--- a/test/no-element-handle.spec.js
+++ b/test/no-element-handle.spec.js
@@ -79,5 +79,23 @@ new RuleTester().run('no-element-handle', rule, {
 
     // page locator with action
     valid('await page.locator("a").click();'),
+
+    // const $
+    valid('const $ = "text";'),
+
+    // $ as a method
+    valid('$("a");'),
+
+    // this.$ as a method
+    valid('this.$("a");'),
+
+    // internalPage.$ method
+    valid('internalPage.$("a");'),
+
+    // this.page.$$$ method
+    valid('this.page.$$$("div");'),
+
+    // page.$$$ method
+    valid('page.$$$("div");'),
   ],
 });

--- a/test/no-element-handle.spec.js
+++ b/test/no-element-handle.spec.js
@@ -1,0 +1,52 @@
+const { RuleTester } = require('eslint');
+const rule = require('../lib/rules/no-element-handle');
+
+RuleTester.setDefaultConfig({
+  parserOptions: {
+    ecmaVersion: 2018,
+  },
+});
+
+const wrapInTest = (input) => `test('verify noElementHandle rule', async () => { ${input} })`;
+
+const invalid = (code, output) => ({
+  code: wrapInTest(code),
+  errors: [{ messageId: 'noElementHandle' }],
+  output: wrapInTest(output),
+});
+
+const valid = (code) => ({
+  code: wrapInTest(code),
+});
+
+new RuleTester().run('no-element-handle', rule, {
+  invalid: [
+    // element handle as const
+    invalid("const handle = await page.$('text=Submit');", "const handle = page.locator('text=Submit');"),
+
+    // element handle as let
+    invalid("let handle = await page.$('text=Submit');", "let handle = page.locator('text=Submit');"),
+
+    // element handle as expression statement
+    invalid('await page.$("div")', 'page.locator("div")'),
+
+    // element handle click
+    invalid('await (await page.$$("div")).click();', 'await (page.locator("div")).click();'),
+
+    // element handles as const
+    invalid('const handles = await page.$$("a")', 'const handles = page.locator("a")'),
+
+    // element handles as let
+    invalid('let handles = await page.$$("a")', 'let handles = page.locator("a")'),
+
+    // element handles as expression statement
+    invalid('await page.$$("a")', 'page.locator("a")'),
+  ],
+  valid: [
+    // page locator
+    valid('page.locator("a")'),
+
+    // page locator with action
+    valid('await page.locator("a").click();'),
+  ],
+});

--- a/test/no-element-handle.spec.js
+++ b/test/no-element-handle.spec.js
@@ -41,6 +41,21 @@ new RuleTester().run('no-element-handle', rule, {
 
     // element handles as expression statement
     invalid('await page.$$("a")', 'page.locator("a")'),
+
+    // return element handle without awaiting it
+    invalid(
+      'function getHandle() { return page.$("button"); }',
+      'function getHandle() { return page.locator("button"); }'
+    ),
+
+    // missed return for the element handle
+    invalid(
+      'function getHandle() { page.$("button"); }',
+      'function getHandle() { page.locator("button"); }'
+    ),
+
+    // arrow function return element handles without awaiting it
+    invalid('const getHandles = () => page.$$("links");', 'const getHandles = () => page.locator("links");'),
   ],
   valid: [
     // page locator

--- a/test/no-element-handle.spec.js
+++ b/test/no-element-handle.spec.js
@@ -14,7 +14,12 @@ const invalid = (code, output) => ({
   errors: [
     {
       messageId: 'noElementHandle',
-      suggestions: [{ messageId: 'replaceWithLocator', output: wrapInTest(output) }],
+      suggestions: [
+        {
+          messageId: code.includes('page.$$') ? 'replaceElementHandlesWithLocator' : 'replaceElementHandleWithLocator',
+          output: wrapInTest(output),
+        },
+      ],
     },
   ],
 });

--- a/test/no-element-handle.spec.js
+++ b/test/no-element-handle.spec.js
@@ -48,11 +48,20 @@ new RuleTester().run('no-element-handle', rule, {
       'function getHandle() { return page.locator("button"); }'
     ),
 
+    // return element handles without awaiting it
+    invalid(
+      'function getHandle() { return page.$$("button"); }',
+      'function getHandle() { return page.locator("button"); }'
+    ),
+
     // missed return for the element handle
     invalid(
       'function getHandle() { page.$("button"); }',
       'function getHandle() { page.locator("button"); }'
     ),
+
+    // arrow function return element handle without awaiting it
+    invalid('const getHandles = () => page.$("links");', 'const getHandles = () => page.locator("links");'),
 
     // arrow function return element handles without awaiting it
     invalid('const getHandles = () => page.$$("links");', 'const getHandles = () => page.locator("links");'),


### PR DESCRIPTION
**Adds new no-element-handle rule.**

**Description:** 
This rule disallows using the `page.$` element handle and `page.$$` element handles. Because the use of ElementHandle is discouraged, use [Locator](https://playwright.dev/docs/next/api/class-locator) instead. Besides, it can convert an element handle to a locator.