### PR TITLE
Add new "noConditionalInTest" rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -319,3 +319,79 @@ The rule accepts a non-required option to override the default maximum nested de
   ]
 }
 ```
+
+### `no-conditional-in-test`
+
+Disallow conditional statements such as `if`, `switch`, and ternary expressions within tests.
+
+Examples of **incorrect** code for this rule:
+
+```js
+test('foo', async ({ page }) => {
+  if (someCondition) {
+    bar();
+  }
+});
+
+test('bar', async ({ page }) => {
+  switch (mode) {
+    case 'single':
+      generateOne();
+      break;
+    case 'double':
+      generateTwo();
+      break;
+    case 'multiple':
+      generateMany();
+      break;
+  }
+
+  await expect(page.locator('.my-image').count()).toBeGreaterThan(0);
+});
+
+test('baz', async ({ page }) => {
+  const hotkey = process.platform === 'linux' ? ['Control', 'Alt', 'f'] : ['Alt', 'f'];
+  await Promise.all(hotkey.map(x => page.keyboard.down(x)))
+
+  expect(actionIsPerformed()).toBe(true);
+});
+```
+
+Examples of **correct** code for this rule:
+
+```js
+test.describe('my tests', () => {
+  if (someCondition) {
+    test('foo', async ({ page }) => {
+      bar();
+    });
+  }
+});
+
+beforeEach(() => {
+  switch (mode) {
+    case 'single':
+      generateOne();
+      break;
+    case 'double':
+      generateTwo();
+      break;
+    case 'multiple':
+      generateMany();
+      break;
+  }
+});
+
+test('bar', async ({ page }) => {
+  await expect(page.locator('.my-image').count()).toBeGreaterThan(0);
+})
+
+const hotkey = process.platform === 'linux' ? ['Control', 'Alt', 'f'] : ['Alt', 'f'];
+
+test('baz', async ({ page }) => {
+  await Promise.all(hotkey.map(x => page.keyboard.down(x)))
+
+  expect(actionIsPerformed()).toBe(true);
+});
+
+```

--- a/lib/index.js
+++ b/lib/index.js
@@ -7,6 +7,7 @@ const noSkippedTest = require("./rules/no-skipped-test");
 const noWaitForTimeout = require("./rules/no-wait-for-timeout");
 const noForceOption = require("./rules/no-force-option");
 const maxNestedDescribe = require("./rules/max-nested-describe");
+const noConditionalInTest = require("./rules/no-conditional-in-test");
 
 module.exports = {
   configs: {
@@ -26,6 +27,7 @@ module.exports = {
         "playwright/no-wait-for-timeout": "warn",
         "playwright/no-force-option": "warn",
         "playwright/max-nested-describe": "warn",
+        "playwright/no-conditional-in-test": "warn",
       },
     },
     "jest-playwright": {
@@ -71,5 +73,6 @@ module.exports = {
     "no-wait-for-timeout": noWaitForTimeout,
     "no-force-option": noForceOption,
     "max-nested-describe": maxNestedDescribe,
+    "no-conditional-in-test": noConditionalInTest,
   },
 };

--- a/lib/rules/no-conditional-in-test.js
+++ b/lib/rules/no-conditional-in-test.js
@@ -1,0 +1,50 @@
+
+const { isTestIdentifier, isDescribeCall, isHookCall } = require('../utils/ast');
+
+/** @type {import('eslint').Rule.RuleModule} */
+module.exports = {
+  create(context) {
+    let inTestCase = false;
+
+    function maybeReportConditional(node) {
+      if (inTestCase) {
+        context.report({
+          messageId: 'conditionalInTest',
+          node,
+        });
+      }
+    }
+
+    return {
+      CallExpression(node) {
+        const { callee } = node;
+        if((isTestIdentifier(callee)) && !isDescribeCall(node) && !isHookCall(node)) {
+          inTestCase = true;
+        }
+      },
+      'CallExpression:exit'(node) {
+        const { callee } = node;
+        if((isTestIdentifier(callee)) && !isDescribeCall(node) && !isHookCall(node)) {
+          inTestCase = false;
+        }
+      },
+      IfStatement: maybeReportConditional,
+      SwitchStatement: maybeReportConditional,
+      ConditionalExpression: maybeReportConditional,
+      LogicalExpression: maybeReportConditional,
+    };
+  },
+  meta: {
+    docs: {
+      category: 'Best Practices',
+      description: 'Disallow conditional logic in tests',
+      recommended: false,
+      url: 'https://github.com/playwright-community/eslint-plugin-playwright#no-conditional-in-test',
+    },
+    messages: {
+      conditionalInTest: 'Avoid having conditionals in tests',
+    },
+    type: 'problem',
+    schema: [],
+  },
+};

--- a/lib/utils/ast.js
+++ b/lib/utils/ast.js
@@ -16,8 +16,12 @@ function isCalleeProperty({ callee }, name) {
   );
 }
 
+function isTestObject({ object }) {
+  return object && isIdentifier(object, 'test');
+}
+
 function isTestIdentifier(node) {
-  return node.object && node.object.type === 'Identifier' && node.object.name === 'test';
+  return isIdentifier(node, 'test') || isTestObject(node);
 }
 
 function hasAnnotation(node, annotation) {
@@ -70,9 +74,8 @@ function isDescribeAlias(node) {
 }
 
 function isDescribeProperty(node) {
-  const describeProperties = new Set(['parallel', 'serial', 'only', 'skip']);
-
-  return isIdentifier(node) && describeProperties.has(node.name);
+  const describeProperties = ['parallel', 'serial', 'only', 'skip'];
+  return describeProperties.some(prop => isIdentifier(node, prop));
 }
 
 function isDescribeCall(node) {
@@ -103,6 +106,11 @@ function isDescribeCall(node) {
   return false;
 };
 
+function isHookCall(node) {
+  const hooks = ['beforeAll', 'beforeEach', 'afterAll', 'afterEach'];
+  return hooks.some(hook => isCalleeProperty(node, hook));
+}
+
 module.exports = {
   isObject,
   isCalleeProperty,
@@ -114,5 +122,6 @@ module.exports = {
   isBinaryExpression,
   isCallExpression,
   isMemberExpression,
-  isDescribeCall
+  isDescribeCall,
+  isHookCall
 };

--- a/test/no-conditional-in-test.spec.js
+++ b/test/no-conditional-in-test.spec.js
@@ -1,0 +1,231 @@
+const { runRuleTester } = require('../lib/utils/rule-tester');
+const rule = require('../lib/rules/no-conditional-in-test');
+
+const invalid = (code, errors) => ({
+  code,
+  errors: errors || [
+    {
+      messageId: 'conditionalInTest',
+    },
+  ],
+});
+
+const valid = (code) => ({
+  code
+});
+
+runRuleTester('no-conditional-in-test', rule, {
+  invalid: [
+    invalid('test("foo", () => { if (true) { expect(1).toBe(1); } });'),
+    invalid(`
+      test.describe("foo", () => {
+        test("bar", () => {
+          if (someCondition()) {
+            expect(1).toBe(1);
+          } else {
+            expect(2).toBe(2);
+          }
+        });
+      });
+    `),
+    invalid(`
+      describe('foo', () => {
+        test('bar', () => {
+          if ('bar') {}
+        })
+      })
+    `),
+    invalid(`
+      describe('foo', () => {
+        test('bar', () => {
+          if ('bar') {}
+        })
+        test('baz', () => {
+          if ('qux') {}
+          if ('quux') {}
+        })
+      })
+    `, 
+    [
+      {
+        messageId: 'conditionalInTest',
+      },
+      {
+        messageId: 'conditionalInTest',
+      },
+      {
+        messageId: 'conditionalInTest',
+      },
+    ]),
+    invalid(`
+      test("foo", function () {
+        switch(someCondition()) {
+          case 1:
+            expect(1).toBe(1);
+            break;
+          case 2:
+            expect(2).toBe(2);
+            break;
+        }
+      });
+    `),
+    invalid(`
+      test('foo', () => {
+        if ('bar') {}
+      })
+    `),
+    invalid(`
+      test('foo', () => {
+        bar ? expect(1).toBe(1) : expect(2).toBe(2);
+      })
+    `),
+    invalid(`
+      test('foo', function () {
+        bar ? expect(1).toBe(1) : expect(2).toBe(2);
+      })
+    `),
+    invalid(`
+      test('foo', function () {
+        if ('bar') {}
+      })
+    `),
+    invalid(`
+      test('foo', async function ({ page }) {
+        await asyncFunc();
+        if ('bar') {}
+      })
+    `),
+    invalid(`
+      test.skip('foo', () => {
+        if ('bar') {}
+      })
+    `),
+    invalid(`
+      test.skip('foo', async ({ page }) => {
+        await asyncFunc();
+        if ('bar') {}
+      })
+    `),
+    invalid(`
+      test.skip('foo', function () {
+        if ('bar') {}
+      })
+    `),
+    invalid(`
+      test.only('foo', () => {
+        if ('bar') {}
+      })
+    `),
+    invalid(`
+      test.fixme('foo', () => {
+        if ('bar') {}
+      })
+    `),
+    invalid(`
+      test('foo', () => {
+        callExpression()
+        if ('bar') {}
+      })
+    `),
+    invalid(`
+      testDetails.forEach((detail) => {
+        test(detail.name, () => {
+          if (detail.fail) {
+            test.fail();
+          } else {
+            expect(true).toBe(true);
+          }
+        })
+      });
+    `)
+  ],
+  valid: [
+    'test("foo", () => { expect(1).toBe(1); });',
+    'test.fixme("some broken test", () => { expect(1).toBe(1); });',
+    'test.describe("foo", () => { if(true) { test("bar", () => { expect(true).toBe(true); }); } });',
+    'test.skip(process.env.APP_VERSION === "v1", "There are no settings in v1");',
+    'test("some slow test", () => { test.slow(); })',
+    'const foo = bar ? foo : baz;',
+    valid(`
+      test.describe('foo', () => {
+        test.afterEach(() => {
+          if ('bar') {}
+        });
+      })
+    `),
+    valid(`
+      test.describe('foo', () => {
+        test.beforeEach(() => {
+          if ('bar') {}
+        });
+      })
+    `),
+    valid(`
+      test.describe('foo', function () {
+        test.beforeEach(function () {
+          if ('bar') {}
+        });
+      })
+    `),
+    valid(`
+      test.describe.parallel('foo', function () {
+        test.beforeEach(function () {
+          if ('bar') {}
+        });
+      })
+    `),
+    valid(`
+      test.describe.parallel.only('foo', function () {
+        test.beforeEach(function () {
+          if ('bar') {}
+        });
+      })
+    `),
+    valid(`
+      test.describe.serial('foo', function () {
+        test.beforeEach(function () {
+          if ('bar') {}
+        });
+      })
+    `),
+    valid(`
+      test.describe.serial.only('foo', function () {
+        test.beforeEach(function () {
+          if ('bar') {}
+        });
+      })
+    `),
+    valid(`
+      const values = something.map((thing) => {
+        if (thing.isFoo) {
+          return thing.foo
+        } else {
+          return thing.bar;
+        }
+      });
+
+      test.describe('valid', () => {
+        test('still valid', () => {
+          expect(values).toStrictEqual(['foo']);
+        });
+      });
+    `),
+    valid(`
+      describe('valid', () => {
+        const values = something.map((thing) => {
+          if (thing.isFoo) {
+            return thing.foo
+          } else {
+            return thing.bar;
+          }
+        });
+
+        test.describe('still valid', () => {
+          test('really still valid', () => {
+            expect(values).toStrictEqual(['foo']);
+          });
+        });
+      });
+    `)
+  ]
+});

--- a/test/no-conditional-in-test.spec.js
+++ b/test/no-conditional-in-test.spec.js
@@ -10,10 +10,6 @@ const invalid = (code, errors) => ({
   ],
 });
 
-const valid = (code) => ({
-  code
-});
-
 runRuleTester('no-conditional-in-test', rule, {
   invalid: [
     invalid('test("foo", () => { if (true) { expect(1).toBe(1); } });'),
@@ -146,57 +142,42 @@ runRuleTester('no-conditional-in-test', rule, {
     'test.skip(process.env.APP_VERSION === "v1", "There are no settings in v1");',
     'test("some slow test", () => { test.slow(); })',
     'const foo = bar ? foo : baz;',
-    valid(`
-      test.describe('foo', () => {
+    `test.describe('foo', () => {
         test.afterEach(() => {
           if ('bar') {}
         });
-      })
-    `),
-    valid(`
-      test.describe('foo', () => {
+      })`,
+    `test.describe('foo', () => {
         test.beforeEach(() => {
           if ('bar') {}
         });
-      })
-    `),
-    valid(`
-      test.describe('foo', function () {
+      })`,
+    `test.describe('foo', function () {
         test.beforeEach(function () {
           if ('bar') {}
         });
-      })
-    `),
-    valid(`
-      test.describe.parallel('foo', function () {
+      })`,
+    `test.describe.parallel('foo', function () {
         test.beforeEach(function () {
           if ('bar') {}
         });
-      })
-    `),
-    valid(`
-      test.describe.parallel.only('foo', function () {
+      })`,
+    `test.describe.parallel.only('foo', function () {
         test.beforeEach(function () {
           if ('bar') {}
         });
-      })
-    `),
-    valid(`
-      test.describe.serial('foo', function () {
+      })`,
+    `test.describe.serial('foo', function () {
         test.beforeEach(function () {
           if ('bar') {}
         });
-      })
-    `),
-    valid(`
-      test.describe.serial.only('foo', function () {
+      })`,
+    `test.describe.serial.only('foo', function () {
         test.beforeEach(function () {
           if ('bar') {}
         });
-      })
-    `),
-    valid(`
-      const values = something.map((thing) => {
+      })`,
+    `const values = something.map((thing) => {
         if (thing.isFoo) {
           return thing.foo
         } else {
@@ -208,10 +189,8 @@ runRuleTester('no-conditional-in-test', rule, {
         test('still valid', () => {
           expect(values).toStrictEqual(['foo']);
         });
-      });
-    `),
-    valid(`
-      describe('valid', () => {
+      });`,
+    `describe('valid', () => {
         const values = something.map((thing) => {
           if (thing.isFoo) {
             return thing.foo
@@ -225,7 +204,6 @@ runRuleTester('no-conditional-in-test', rule, {
             expect(values).toStrictEqual(['foo']);
           });
         });
-      });
-    `)
+      });`
   ]
 });


### PR DESCRIPTION
Closes #58 

**Description:**

Adds a new rule to disallow conditional statements such as `if`, `switch`, and ternary expressions within tests. Adapted from [this eslint-plugin-jest rule](https://github.com/jest-community/eslint-plugin-jest/blob/main/docs/rules/no-conditional-in-test.md) and modified for Playwright.