### PR TITLE
Fix conditionals

### DIFF
--- a/src/utils/ast.ts
+++ b/src/utils/ast.ts
@@ -1,3 +1,4 @@
+import { Rule } from 'eslint';
 import * as ESTree from 'estree';
 
 export function getNodeName(node: ESTree.Node) {
@@ -90,4 +91,32 @@ export function isDescribeCall(node: ESTree.CallExpression) {
   }
 
   return false;
+}
+
+type NodeWithParent<T extends ESTree.Node['type']> = Extract<
+  ESTree.Node,
+  { type: T }
+> &
+  Rule.NodeParentExtension;
+
+export function findParent<T extends ESTree.Node['type']>(
+  node: ESTree.Node & Rule.NodeParentExtension,
+  type: T
+): NodeWithParent<T> | undefined {
+  if (!node.parent) return;
+
+  return node.parent.type === type
+    ? (node.parent as unknown as NodeWithParent<T>)
+    : findParent(node.parent, type);
+}
+
+export function isTest(node: ESTree.CallExpression) {
+  return (
+    isTestIdentifier(node.callee) &&
+    !isDescribeCall(node) &&
+    node.arguments.length === 2 &&
+    ['ArrowFunctionExpression', 'FunctionExpression'].includes(
+      node.arguments[1].type
+    )
+  );
 }

--- a/test/spec/no-conditional-in-test.spec.ts
+++ b/test/spec/no-conditional-in-test.spec.ts
@@ -126,6 +126,13 @@ runRuleTester('no-conditional-in-test', rule, {
         })
       });
     `),
+    invalid(`
+      test('test', async ({ page }) => {
+        await test.step('step', async () => {
+          if (true) {}
+        });
+      });
+    `),
   ],
   valid: [
     'test("foo", () => { expect(1).toBe(1); });',
@@ -199,17 +206,34 @@ runRuleTester('no-conditional-in-test', rule, {
       });`,
     // Conditionals are only disallowed at the root level. Nested conditionals
     // are common and valid.
-    `test('nested', () => {
+    `test('nested', async ({ page }) => {
       const [request] = await Promise.all([
         page.waitForRequest(request => request.url() === 'foo' && request.method() === 'GET'),
         page.click('button'),
       ]);
     })`,
-    `test('nested', () => {
+    `test('nested', async ({ page }) => {
+      await page.waitForRequest(request => request.url() === 'foo' && request.method() === 'GET')
+    })`,
+    `test.fixme('nested', async ({ page }) => {
+      await page.waitForRequest(request => request.url() === 'foo' && request.method() === 'GET')
+    })`,
+    `test.only('nested', async ({ page }) => {
       await page.waitForRequest(request => request.url() === 'foo' && request.method() === 'GET')
     })`,
     `test('nested', () => {
       test.skip(true && false)
+    })`,
+    `test('nested', () => {
+      test.skip(
+        ({ baseURL }) => (baseURL || "").includes("localhost"),
+        "message",
+      )
+    })`,
+    `test('test', async ({ page }) => {
+      await test.step('step', async () => {
+        await page.waitForRequest(request => request.url() === 'foo' && request.method() === 'GET')
+      });
     })`,
   ],
 });

--- a/test/spec/no-conditional-in-test.spec.ts
+++ b/test/spec/no-conditional-in-test.spec.ts
@@ -40,15 +40,9 @@ runRuleTester('no-conditional-in-test', rule, {
       })
     `,
       [
-        {
-          messageId: 'conditionalInTest',
-        },
-        {
-          messageId: 'conditionalInTest',
-        },
-        {
-          messageId: 'conditionalInTest',
-        },
+        { messageId: 'conditionalInTest' },
+        { messageId: 'conditionalInTest' },
+        { messageId: 'conditionalInTest' },
       ]
     ),
     invalid(`
@@ -203,5 +197,19 @@ runRuleTester('no-conditional-in-test', rule, {
           });
         });
       });`,
+    // Conditionals are only disallowed at the root level. Nested conditionals
+    // are common and valid.
+    `test('nested', () => {
+      const [request] = await Promise.all([
+        page.waitForRequest(request => request.url() === 'foo' && request.method() === 'GET'),
+        page.click('button'),
+      ]);
+    })`,
+    `test('nested', () => {
+      await page.waitForRequest(request => request.url() === 'foo' && request.method() === 'GET')
+    })`,
+    `test('nested', () => {
+      test.skip(true && false)
+    })`,
   ],
 });


### PR DESCRIPTION
Fixes #76

Reduces the scope of this rule to only apply to top level conditional expressions in tests.