### PR TITLE
Always report missing await for `expect.poll()` regardless of matcher

### DIFF
--- a/docs/rules/missing-playwright-await.md
+++ b/docs/rules/missing-playwright-await.md
@@ -8,6 +8,7 @@ Example of **incorrect** code for this rule:
 
 ```javascript
 expect(page).toMatchText('text');
+expect.poll(() => foo).toBe(true);
 
 test.step('clicks the button', async () => {
   await page.click('button');
@@ -18,6 +19,7 @@ Example of **correct** code for this rule:
 
 ```javascript
 await expect(page).toMatchText('text');
+await expect.poll(() => foo).toBe(true);
 
 await test.step('clicks the button', async () => {
   await page.click('button');

--- a/test/spec/missing-playwright-await.spec.ts
+++ b/test/spec/missing-playwright-await.spec.ts
@@ -116,6 +116,11 @@ runRuleTester('missing-playwright-await', rule, {
     valid('await expect.soft(page).toHaveText("text")'),
     valid('await expect.soft(page).not.toHaveText("text")'),
 
+    // expect.poll
+    valid('await expect.poll(() => foo).toBe("text")'),
+    valid('await expect["poll"](() => foo).toContain("text")'),
+    valid('await expect[`poll`](() => foo).toBeTruthy()'),
+
     // test.step
     valid("await test.step('foo', async () => {})"),
   ],

--- a/test/spec/missing-playwright-await.spec.ts
+++ b/test/spec/missing-playwright-await.spec.ts
@@ -66,17 +66,17 @@ runRuleTester('missing-playwright-await', rule, {
 
     // expect.poll
     invalid(
-      'expect',
+      'expectPoll',
       'expect.poll(() => foo).toBe(true)',
       'await expect.poll(() => foo).toBe(true)'
     ),
     invalid(
-      'expect',
+      'expectPoll',
       'expect["poll"](() => foo)["toContain"]("bar")',
       'await expect["poll"](() => foo)["toContain"]("bar")'
     ),
     invalid(
-      'expect',
+      'expectPoll',
       'expect[`poll`](() => foo)[`toBeTruthy`]()',
       'await expect[`poll`](() => foo)[`toBeTruthy`]()'
     ),
@@ -92,8 +92,8 @@ runRuleTester('missing-playwright-await', rule, {
       "test['step']('foo', async () => {})",
       "await test['step']('foo', async () => {})"
     ),
-  ].slice(0, 3),
-  valid: [] || [
+  ],
+  valid: [
     valid('await expect(page).toBeEditable'),
     valid('await expect(page).toEqualTitle("text")'),
     valid('await expect(page).not.toHaveText("text")'),

--- a/test/spec/missing-playwright-await.spec.ts
+++ b/test/spec/missing-playwright-await.spec.ts
@@ -64,6 +64,23 @@ runRuleTester('missing-playwright-await', rule, {
       'await expect[`soft`](page)[`toBeChecked`]()'
     ),
 
+    // expect.poll
+    invalid(
+      'expect',
+      'expect.poll(() => foo).toBe(true)',
+      'await expect.poll(() => foo).toBe(true)'
+    ),
+    invalid(
+      'expect',
+      'expect["poll"](() => foo)["toContain"]("bar")',
+      'await expect["poll"](() => foo)["toContain"]("bar")'
+    ),
+    invalid(
+      'expect',
+      'expect[`poll`](() => foo)[`toBeTruthy`]()',
+      'await expect[`poll`](() => foo)[`toBeTruthy`]()'
+    ),
+
     // test.step
     invalid(
       'testStep',
@@ -75,8 +92,8 @@ runRuleTester('missing-playwright-await', rule, {
       "test['step']('foo', async () => {})",
       "await test['step']('foo', async () => {})"
     ),
-  ],
-  valid: [
+  ].slice(0, 3),
+  valid: [] || [
     valid('await expect(page).toBeEditable'),
     valid('await expect(page).toEqualTitle("text")'),
     valid('await expect(page).not.toHaveText("text")'),


### PR DESCRIPTION
Fixes #97 