### PR TITLE
Add test for no-skipped-test

### DIFF
--- a/test/spec/no-skipped-test.spec.ts
+++ b/test/spec/no-skipped-test.spec.ts
@@ -37,6 +37,7 @@ runRuleTester('no-skipped-test', rule, {
       'test.describe[`skip`]("skip this describe", () => {});',
       'test.describe("skip this describe", () => {});'
     ),
+    invalid('test.skip(browserName === "firefox");', ''),
     invalid('test.skip(browserName === "firefox", "Still working on it");', ''),
     invalid(
       'test.describe.parallel("run in parallel", () => { test.skip(); expect(true).toBe(true); })',


### PR DESCRIPTION
It stops working ESLint in `v0.11.1`. Here is the error log. Can you please release 0.11.2 or 0.12.0?
```log
> eslint '**/*.ts'


Oops! Something went wrong! :(

ESLint: 8.23.1

TypeError: Cannot read properties of undefined (reading 'type')
Occurred while linting /Users/nix6839/programming/playground/playwrigt-lint-error/tests/error-lint.test.ts:4
Rule: "playwright/no-skipped-test"
    at isLiteral (/Users/nix6839/programming/playground/playwrigt-lint-error/node_modules/.pnpm/eslint-plugin-playwright@0.11.1_eslint@8.23.1/node_modules/eslint-plugin-playwright/lib/utils/ast.js:41:18)
    at isStringLiteral (/Users/nix6839/programming/playground/playwrigt-lint-error/node_modules/.pnpm/eslint-plugin-playwright@0.11.1_eslint@8.23.1/node_modules/eslint-plugin-playwright/lib/utils/ast.js:47:12)
    at getSkipRange (/Users/nix6839/programming/playground/playwrigt-lint-error/node_modules/.pnpm/eslint-plugin-playwright@0.11.1_eslint@8.23.1/node_modules/eslint-plugin-playwright/lib/rules/no-skipped-test.js:20:39)
    at Object.fix (/Users/nix6839/programming/playground/playwrigt-lint-error/node_modules/.pnpm/eslint-plugin-playwright@0.11.1_eslint@8.23.1/node_modules/eslint-plugin-playwright/lib/rules/no-skipped-test.js:38:67)
    at normalizeFixes (/Users/nix6839/programming/playground/playwrigt-lint-error/node_modules/.pnpm/eslint@8.23.1/node_modules/eslint/lib/linter/report-translator.js:193:28)
    at /Users/nix6839/programming/playground/playwrigt-lint-error/node_modules/.pnpm/eslint@8.23.1/node_modules/eslint/lib/linter/report-translator.js:223:22
    at Array.map (<anonymous>)
    at mapSuggestions (/Users/nix6839/programming/playground/playwrigt-lint-error/node_modules/.pnpm/eslint@8.23.1/node_modules/eslint/lib/linter/report-translator.js:217:10)
    at /Users/nix6839/programming/playground/playwrigt-lint-error/node_modules/.pnpm/eslint@8.23.1/node_modules/eslint/lib/linter/report-translator.js:365:55
    at Object.report (/Users/nix6839/programming/playground/playwrigt-lint-error/node_modules/.pnpm/eslint@8.23.1/node_modules/eslint/lib/linter/linter.js:1085:41)
 ELIFECYCLE  Command failed with exit code 2.
```