### PR TITLE
Improve expect calls to use `parseExpectCall`

### DIFF
--- a/src/rules/no-restricted-matchers.ts
+++ b/src/rules/no-restricted-matchers.ts
@@ -2,6 +2,12 @@ import { Rule } from 'eslint';
 import { getStringValue } from '../utils/ast';
 import { parseExpectCall } from '../utils/parseExpectCall';
 
+// To properly test matcher chains, we ensure the entire chain is surrounded by
+// periods so that the `includes` matcher doesn't match substrings. For example,
+// `not` should only match `expect().not.something()` but it should not match
+// `expect().nothing()`.
+const wrap = (chain: string) => `.${chain}.`;
+
 export default {
   create(context) {
     const restrictedChains = (context.options?.[0] ?? {}) as {
@@ -18,7 +24,7 @@ export default {
         const chain = expectCall.members.map(getStringValue).join('.');
 
         Object.entries(restrictedChains)
-          .filter(([restriction]) => chain.includes(restriction))
+          .filter(([restriction]) => wrap(chain).includes(wrap(restriction)))
           .forEach(([restriction, message]) => {
             context.report({
               messageId: message ? 'restrictedWithMessage' : 'restricted',

--- a/src/rules/no-restricted-matchers.ts
+++ b/src/rules/no-restricted-matchers.ts
@@ -1,5 +1,6 @@
 import { Rule } from 'eslint';
-import { getMatchers, getStringValue, isExpectCall } from '../utils/ast';
+import { getStringValue } from '../utils/ast';
+import { parseExpectCall } from '../utils/parseExpectCall';
 
 export default {
   create(context) {
@@ -9,31 +10,25 @@ export default {
 
     return {
       CallExpression(node) {
-        if (!isExpectCall(node)) {
-          return;
-        }
+        const expectCall = parseExpectCall(node);
+        if (!expectCall) return;
 
-        const matchers = getMatchers(node);
-        const permutations = matchers.map((_, i) => matchers.slice(0, i + 1));
+        // Stringify the expect call chain to compare to the list of restricted
+        // matcher chains.
+        const chain = expectCall.members.map(getStringValue).join('.');
 
-        for (const permutation of permutations) {
-          const chain = permutation.map(getStringValue).join('.');
-
-          if (chain in restrictedChains) {
-            const message = restrictedChains[chain];
-
+        Object.entries(restrictedChains)
+          .filter(([restriction]) => chain.includes(restriction))
+          .forEach(([restriction, message]) => {
             context.report({
               messageId: message ? 'restrictedWithMessage' : 'restricted',
-              data: { message: message ?? '', chain },
+              data: { message: message ?? '', restriction },
               loc: {
-                start: permutation[0].loc!.start,
-                end: permutation[permutation.length - 1].loc!.end,
+                start: expectCall.members[0].loc!.start,
+                end: expectCall.members[expectCall.members.length - 1].loc!.end,
               },
             });
-
-            break;
-          }
-        }
+          });
       },
     };
   },
@@ -45,7 +40,7 @@ export default {
       url: 'https://github.com/playwright-community/eslint-plugin-playwright/tree/main/docs/rules/no-restricted-matchers.md',
     },
     messages: {
-      restricted: 'Use of `{{chain}}` is disallowed',
+      restricted: 'Use of `{{restriction}}` is disallowed',
       restrictedWithMessage: '{{message}}',
     },
     type: 'suggestion',

--- a/src/rules/no-useless-not.ts
+++ b/src/rules/no-useless-not.ts
@@ -1,56 +1,45 @@
 import { Rule } from 'eslint';
-import * as ESTree from 'estree';
-import { getStringValue, isExpectCall, isPropertyAccessor } from '../utils/ast';
+import { getStringValue } from '../utils/ast';
+import { getRangeOffset, replaceAccessorFixer } from '../utils/fixer';
+import { parseExpectCall } from '../utils/parseExpectCall';
 
-const matcherMap = {
+const matcherMap: Record<string, string> = {
   toBeVisible: 'toBeHidden',
   toBeHidden: 'toBeVisible',
   toBeEnabled: 'toBeDisabled',
   toBeDisabled: 'toBeEnabled',
 };
 
-const getRangeOffset = (node: ESTree.Node) =>
-  node.type === 'Identifier' ? 0 : 1;
-
 export default {
   create(context) {
     return {
-      MemberExpression(node) {
-        if (
-          node.object.type === 'MemberExpression' &&
-          node.object.object.type === 'CallExpression' &&
-          isExpectCall(node.object.object) &&
-          isPropertyAccessor(node.object, 'not')
-        ) {
-          const matcher = getStringValue(node.property) as
-            | keyof typeof matcherMap
-            | undefined;
+      CallExpression(node) {
+        const expectCall = parseExpectCall(node);
+        if (!expectCall) return;
 
-          if (matcher && matcher in matcherMap) {
-            const { property } = node.object;
+        // As the name implies, this rule only implies if the not modifier is
+        // part of the matcher chain
+        const notModifier = expectCall.modifiers.find(
+          (mod) => getStringValue(mod) === 'not'
+        );
+        if (!notModifier) return;
 
-            context.report({
-              fix: (fixer) => [
-                fixer.removeRange([
-                  property.range![0] - getRangeOffset(property),
-                  property.range![1] + 1,
-                ]),
-                fixer.replaceTextRange(
-                  [
-                    node.property.range![0] + getRangeOffset(node.property),
-                    node.property.range![1] - getRangeOffset(node.property),
-                  ],
-                  matcherMap[matcher]
-                ),
-              ],
-              messageId: 'noUselessNot',
-              node: node,
-              data: {
-                old: matcher,
-                new: matcherMap[matcher],
-              },
-            });
-          }
+        // This rule only applies to specific matchers that have opposites
+        if (expectCall.matcherName in matcherMap) {
+          const newMatcher = matcherMap[expectCall.matcherName];
+
+          context.report({
+            fix: (fixer) => [
+              fixer.removeRange([
+                notModifier.range![0] - getRangeOffset(notModifier),
+                notModifier.range![1] + 1,
+              ]),
+              replaceAccessorFixer(fixer, expectCall.matcher, newMatcher),
+            ],
+            messageId: 'noUselessNot',
+            node: node,
+            data: { old: expectCall.matcherName, new: newMatcher },
+          });
         }
       },
     };

--- a/src/rules/valid-expect.ts
+++ b/src/rules/valid-expect.ts
@@ -1,8 +1,9 @@
 import { Rule } from 'eslint';
-import { isExpectCall, isPropertyAccessor } from '../utils/ast';
+import { isPropertyAccessor } from '../utils/ast';
 import { NodeWithParent } from '../utils/types';
 import * as ESTree from 'estree';
 import { getAmountData } from '../utils/misc';
+import { parseExpectCall } from '../utils/parseExpectCall';
 
 function isMatcherFound(node: NodeWithParent) {
   if (node.parent.type !== 'MemberExpression') {
@@ -53,7 +54,8 @@ export default {
 
     return {
       CallExpression(node) {
-        if (!isExpectCall(node)) return;
+        const expectCall = parseExpectCall(node);
+        if (!expectCall) return;
 
         const result = isMatcherFound(node);
         if (!result.found) {

--- a/src/rules/valid-expect.ts
+++ b/src/rules/valid-expect.ts
@@ -1,24 +1,9 @@
 import { Rule } from 'eslint';
-import { isPropertyAccessor } from '../utils/ast';
+import { isExpectCall } from '../utils/ast';
 import { NodeWithParent } from '../utils/types';
 import * as ESTree from 'estree';
 import { getAmountData } from '../utils/misc';
 import { parseExpectCall } from '../utils/parseExpectCall';
-
-function isMatcherFound(node: NodeWithParent) {
-  if (node.parent.type !== 'MemberExpression') {
-    return { found: false, node };
-  }
-
-  if (
-    isPropertyAccessor(node.parent, 'not') &&
-    node.parent.parent.type !== 'MemberExpression'
-  ) {
-    return { found: false, node: node.parent };
-  }
-
-  return { found: true, node };
-}
 
 function isMatcherCalled(node: NodeWithParent): {
   called: boolean;
@@ -54,12 +39,11 @@ export default {
 
     return {
       CallExpression(node) {
-        const expectCall = parseExpectCall(node);
-        if (!expectCall) return;
+        if (!isExpectCall(node)) return;
 
-        const result = isMatcherFound(node);
-        if (!result.found) {
-          context.report({ node: result.node, messageId: 'matcherNotFound' });
+        const expectCall = parseExpectCall(node);
+        if (!expectCall) {
+          context.report({ node, messageId: 'matcherNotFound' });
         } else {
           const result = isMatcherCalled(node);
 

--- a/src/utils/fixer.ts
+++ b/src/utils/fixer.ts
@@ -1,7 +1,8 @@
 import { Rule } from 'eslint';
 import * as ESTree from 'estree';
 
-const getOffset = (node: ESTree.Node) => (node.type === 'Identifier' ? 0 : 1);
+export const getRangeOffset = (node: ESTree.Node) =>
+  node.type === 'Identifier' ? 0 : 1;
 
 /**
  * Replaces an accessor node with the given `text`.
@@ -17,7 +18,7 @@ export function replaceAccessorFixer(
   const [start, end] = node.range!;
 
   return fixer.replaceTextRange(
-    [start + getOffset(node), end - getOffset(node)],
+    [start + getRangeOffset(node), end - getRangeOffset(node)],
     text
   );
 }

--- a/src/utils/parseExpectCall.ts
+++ b/src/utils/parseExpectCall.ts
@@ -10,8 +10,9 @@ function getExpectArguments(node: Rule.Node): ESTree.Node[] {
 }
 
 export interface ParsedExpectCall {
-  matcherName: string;
+  members: ESTree.Node[];
   matcher: ESTree.Node;
+  matcherName: string;
   modifiers: ESTree.Node[];
   args: ESTree.Node[];
 }
@@ -23,11 +24,12 @@ export function parseExpectCall(
     return;
   }
 
+  const members = getMatchers(node);
   const modifiers: ESTree.Node[] = [];
   let matcher: Rule.Node | undefined;
 
   // Separate the matchers (e.g. toBe) from modifiers (e.g. not)
-  getMatchers(node).forEach((item) => {
+  members.forEach((item) => {
     if (MODIFIER_NAMES.has(getStringValue(item))) {
       modifiers.push(item);
     } else {
@@ -41,9 +43,10 @@ export function parseExpectCall(
   }
 
   return {
-    matcherName: getStringValue(matcher),
+    members,
     matcher,
-    args: getExpectArguments(matcher),
+    matcherName: getStringValue(matcher),
     modifiers,
+    args: getExpectArguments(matcher),
   };
 }

--- a/test/spec/no-restricted-matchers.spec.ts
+++ b/test/spec/no-restricted-matchers.spec.ts
@@ -45,7 +45,7 @@ runRuleTester('no-restricted-matchers', rule, {
       errors: [
         {
           messageId: 'restricted',
-          data: { message: '', chain: 'toBe' },
+          data: { message: '', restriction: 'toBe' },
           column: 11,
           line: 1,
         },
@@ -57,7 +57,7 @@ runRuleTester('no-restricted-matchers', rule, {
       errors: [
         {
           messageId: 'restricted',
-          data: { message: '', chain: 'toBe' },
+          data: { message: '', restriction: 'toBe' },
           column: 16,
           line: 1,
         },
@@ -69,7 +69,7 @@ runRuleTester('no-restricted-matchers', rule, {
       errors: [
         {
           messageId: 'restricted',
-          data: { message: '', chain: 'toBe' },
+          data: { message: '', restriction: 'toBe' },
           column: 25,
           line: 1,
         },
@@ -81,7 +81,7 @@ runRuleTester('no-restricted-matchers', rule, {
       errors: [
         {
           messageId: 'restricted',
-          data: { message: '', chain: 'not' },
+          data: { message: '', restriction: 'not' },
           column: 11,
           line: 1,
         },
@@ -93,7 +93,7 @@ runRuleTester('no-restricted-matchers', rule, {
       errors: [
         {
           messageId: 'restricted',
-          data: { message: '', chain: 'not.toBeTruthy' },
+          data: { message: '', restriction: 'not.toBeTruthy' },
           endColumn: 25,
           column: 11,
           line: 1,
@@ -106,7 +106,7 @@ runRuleTester('no-restricted-matchers', rule, {
       errors: [
         {
           messageId: 'restricted',
-          data: { message: '', chain: 'not' },
+          data: { message: '', restriction: 'not' },
           column: 19,
           line: 1,
         },
@@ -118,7 +118,7 @@ runRuleTester('no-restricted-matchers', rule, {
       errors: [
         {
           messageId: 'restricted',
-          data: { message: '', chain: 'not.toBeTruthy' },
+          data: { message: '', restriction: 'not.toBeTruthy' },
           endColumn: 39,
           column: 25,
           line: 1,
@@ -133,7 +133,7 @@ runRuleTester('no-restricted-matchers', rule, {
           messageId: 'restrictedWithMessage',
           data: {
             message: 'Prefer `toStrictEqual` instead',
-            chain: 'toBe',
+            restriction: 'toBe',
           },
           column: 11,
           line: 1,
@@ -148,7 +148,7 @@ runRuleTester('no-restricted-matchers', rule, {
           messageId: 'restrictedWithMessage',
           data: {
             message: 'Use not.toContainText instead',
-            chain: 'not.toHaveText',
+            restriction: 'not.toHaveText',
           },
           endColumn: 27,
           column: 13,

--- a/test/spec/no-restricted-matchers.spec.ts
+++ b/test/spec/no-restricted-matchers.spec.ts
@@ -37,6 +37,14 @@ runRuleTester('no-restricted-matchers', rule, {
       code: 'expect[`poll`](() => true)[`toBe`](b)',
       options: [{ 'not.toBe': null }],
     },
+    {
+      code: 'expect(a).toHaveKnot(b)',
+      options: [{ not: null }],
+    },
+    {
+      code: 'expect(a).nothing(b)',
+      options: [{ not: null }],
+    },
   ],
   invalid: [
     {


### PR DESCRIPTION
Updates remaining matchers that work with `expect` to use `parseExpectCall`.