### PR TITLE
[WIP] Implement `prefer-inner-text`

### DIFF
--- a/docs/rules/prefer-inner-text.md
+++ b/docs/rules/prefer-inner-text.md
@@ -1,0 +1,22 @@
+# Suggest using `innerText()` (`prefer-inner-text`)
+
+The `textContent()` method is similar to the `innerText()` method, but the
+`innerText()` method shows only human readable elements, while `textContent()`
+also includes text hidden by CSS and the contents of script/style tags.
+
+## Rule details
+
+This rule triggers a warning if `textContent()` is called on a `locator`
+element.
+
+The following patterns are considered warnings:
+
+```javascript
+page.locator("div").textContent();
+```
+
+The following pattern is **not** a warning:
+
+```javascript
+page.locator("div").innerText();
+```

--- a/src/rules/prefer-inner-text.ts
+++ b/src/rules/prefer-inner-text.ts
@@ -1,0 +1,46 @@
+import { Rule } from 'eslint';
+import { isLocatorMethod } from '../utils/ast';
+import { replaceAccessorFixer } from '../utils/fixer';
+
+export default {
+  create(context) {
+    return {
+      CallExpression(node) {
+        const callee = isLocatorMethod(node, 'textContent');
+        if (callee) {
+          context.report({
+            node: callee.property,
+            messageId: 'useInnerText',
+            suggest: [
+              {
+                messageId: 'suggestReplaceWithInnerText',
+                fix: (fixer) => {
+                  return replaceAccessorFixer(
+                    fixer,
+                    callee.property,
+                    'innerText'
+                  );
+                },
+              },
+            ],
+          });
+        }
+      },
+    };
+  },
+  meta: {
+    docs: {
+      description: 'Suggest using `innerText()`',
+      recommended: false,
+      url: 'https://github.com/playwright-community/eslint-plugin-playwright/tree/main/docs/rules/require-inner-text.md',
+    },
+    messages: {
+      useInnerText: 'Use innerText() instead',
+      suggestReplaceWithInnerText: 'Replace with `innerText()`',
+    },
+    hasSuggestions: true,
+    fixable: 'code',
+    type: 'suggestion',
+    schema: [],
+  },
+} as Rule.RuleModule;

--- a/src/utils/ast.ts
+++ b/src/utils/ast.ts
@@ -153,3 +153,23 @@ export function isPageMethod(node: ESTree.CallExpression, name: string) {
     isPropertyAccessor(node.callee, name)
   );
 }
+
+/**
+ * Determine if a node is a method on a playwright locator object.
+ * 
+ * @param node The ESTree call expression
+ * @param name The identifier of the method on the locator object
+ * @returns 
+ */
+export function isLocatorMethod(node: ESTree.CallExpression, name: string): ESTree.MemberExpression | undefined {
+  // TODO: Logic is not finished.
+
+  if (
+    node.callee.type === 'MemberExpression' &&
+    isPropertyAccessor(node.callee, name)
+  ) {
+    return node.callee;
+  }
+
+  return undefined;
+}

--- a/test/spec/perfer-inner-text.spec.ts
+++ b/test/spec/perfer-inner-text.spec.ts
@@ -1,0 +1,110 @@
+import rule from '../../src/rules/prefer-inner-text';
+import { runRuleTester } from '../utils/rule-tester';
+import dedent = require('dedent');
+
+runRuleTester('prefer-inner-text', rule, {
+  valid: [
+    "page.locator('').innerText()",
+    "this.page.locator('').innerText()",
+    "locator('').innerText()",
+    "await locator('').innerText()",
+    {
+      code: dedent`
+        const node = page.locator('div');
+        const text = await node.innerText();
+      `,
+    },
+    "function innerText() {}",
+    "const innerText = \"test\"",
+    dedent`
+      const test = { textContent: 'test' }
+      test.textContent
+    `,
+    dedent`
+      const test = { textContent: () => 'test' }
+      test.textContent()
+    `   
+  ],
+  invalid: [
+    {
+      code: "locator('').textContent()",
+      errors: [
+        {
+          messageId: 'useInnerText',
+          suggestions: [
+            {
+              messageId: 'suggestReplaceWithInnerText',
+              output: "locator('').innerText()",
+            },
+          ],
+          column: 13,
+          endColumn: 24,
+          line: 1,
+        },
+      ],
+    },
+    {
+      code: "page.locator('').textContent()",
+      errors: [
+        {
+          messageId: 'useInnerText',
+          suggestions: [
+            {
+              messageId: 'suggestReplaceWithInnerText',
+              output: "page.locator('').innerText()",
+            },
+          ],
+          column: 18,
+          endColumn: 29,
+          line: 1,
+        },
+      ],
+    },
+    {
+      code: dedent`
+        const node = page.locator('div');
+        const text = await node.textContent();
+      `,
+      errors: [
+        {
+          messageId: 'useInnerText',
+          suggestions: [
+            {
+              messageId: 'suggestReplaceWithInnerText',
+              output: dedent`
+                const node = page.locator('div');
+                const text = await node.innerText();
+              `,
+            },
+          ],
+          column: 25,
+          endColumn: 36,
+          line: 2,
+        },
+      ],
+    },
+    {
+      code: dedent`
+        const node = this.page.locator('div');
+        const text = await node.textContent();
+      `,
+      errors: [
+        {
+          messageId: 'useInnerText',
+          suggestions: [
+            {
+              messageId: 'suggestReplaceWithInnerText',
+              output: dedent`
+                const node = this.page.locator('div');
+                const text = await node.innerText();
+              `,
+            },
+          ],
+          column: 25,
+          endColumn: 36,
+          line: 2,
+        },
+      ],
+    }
+  ],
+});


### PR DESCRIPTION
Work in progress.

Adds an implementation for a rule that warns developers when using `textContent`, and instead suggests using `innerText`.

resolves #127 