### PR TITLE
Add missed assertions to the 'missing-playwright-await' rule

### DIFF
--- a/src/rules/missing-playwright-await.ts
+++ b/src/rules/missing-playwright-await.ts
@@ -57,7 +57,7 @@ const playwrightTestMatchers = [
   'toHaveValue',
   'toHaveValues',
   'toBeAttached',
-  'toBeInViewport'
+  'toBeInViewport',
 ];
 
 function getCallType(


### PR DESCRIPTION
I've just appended missed assertions to the playwright matchers.