### PR TITLE
Improve missing-playwright-await

### DIFF
--- a/test/spec/missing-playwright-await.spec.ts
+++ b/test/spec/missing-playwright-await.spec.ts
@@ -156,7 +156,6 @@ runRuleTester('missing-playwright-await', rule, {
           messageId: 'expect',
         },
       ],
-      only: true,
       output: dedent`
         test('test', async () => {
           const softExpect = expect.configure({ soft: true })
@@ -191,6 +190,8 @@ runRuleTester('missing-playwright-await', rule, {
       ],
       output: test("await test['step']('foo', async () => {})"),
     },
+
+    // Lack of Promise.all
     {
       code: dedent(
         test(`
@@ -252,6 +253,33 @@ runRuleTester('missing-playwright-await', rule, {
           expect(page).toHaveTitle("baz"),
         ])
       `),
+      // only: true,
+    },
+    {
+      code: dedent(
+        test(`
+          const promises = [
+            expect(page.locator("foo")).toHaveText("bar"),
+            expect(page).toHaveTitle("baz"),
+          ]
+
+          await Promise.all(promises)
+        `),
+      ),
+      // only: true,
+    },
+    {
+      code: dedent(
+        test(`
+          const promises = [
+            expect(page.locator("foo")).toHaveText("bar"),
+            expect(page).toHaveTitle("baz"),
+          ]
+
+          return promises
+        `),
+      ),
+      only: true,
     },
   ],
 });

--- a/test/spec/missing-playwright-await.spec.ts
+++ b/test/spec/missing-playwright-await.spec.ts
@@ -253,7 +253,6 @@ runRuleTester('missing-playwright-await', rule, {
           expect(page).toHaveTitle("baz"),
         ])
       `),
-      // only: true,
     },
     {
       code: dedent(
@@ -266,7 +265,6 @@ runRuleTester('missing-playwright-await', rule, {
           await Promise.all(promises)
         `),
       ),
-      // only: true,
     },
     {
       code: dedent(
@@ -279,7 +277,32 @@ runRuleTester('missing-playwright-await', rule, {
           return promises
         `),
       ),
-      only: true,
+    },
+    {
+      code: dedent(
+        test(`
+          const foo = [
+            expect(page.locator("foo")).toHaveText("bar"),
+            expect(page).toHaveTitle("baz"),
+          ]
+
+          const bar = await Promise.all(foo)
+          return bar
+        `),
+      ),
+    },
+    {
+      code: dedent(
+        test(`
+          const foo = [
+            expect(page.locator("foo")).toHaveText("bar"),
+            expect(page).toHaveTitle("baz"),
+          ]
+
+          const bar = foo
+          return bar
+        `),
+      ),
     },
   ],
 });


### PR DESCRIPTION
Fixes #188

This supports more edge cases that are valid.

```js
const promises = [
  expect(page.locator("foo")).toHaveText("bar"),
  expect(page).toHaveTitle("baz"),
]

return promises

const promises = [
  expect(page.locator("foo")).toHaveText("bar"),
  expect(page).toHaveTitle("baz"),
]

await Promise.all(promises)
```