### PR TITLE
chore: Fix formatting of supported rules table

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ command line option.\
 [suggestions](https://eslint.org/docs/latest/developer-guide/working-with-rules#providing-suggestions).
 
 | ✔  | 🔧  | 💡  | Rule                                                                                                                                                | Description                                                       |
-| :-: | :-: | :-: | --------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------- | --- |
+| :-: | :-: | :-: | --------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------- |
 | ✔  |     |     | [expect-expect](https://github.com/playwright-community/eslint-plugin-playwright/tree/main/docs/rules/expect-expect.md)                             | Enforce assertion to be made in a test body                       |
 | ✔  |     |     | [max-expects](https://github.com/playwright-community/eslint-plugin-playwright/tree/main/docs/rules/max-expects.md)                                 | Enforces a maximum number assertion calls in a test body          |     |
 | ✔  |     |     | [max-nested-describe](https://github.com/playwright-community/eslint-plugin-playwright/tree/main/docs/rules/max-nested-describe.md)                 | Enforces a maximum depth to nested describe calls                 |


### PR DESCRIPTION
Hey y'all, I was checking out the supported rules and noticed that commit [acf80a0](https://github.com/playwright-community/eslint-plugin-playwright/commit/acf80a030ea4f90bc887828ac1f7edf7240ac731) seemed to have added an additional column which broke the layout of the supported rules table. This should fix it :)