### PR TITLE
Fix no-standalone-expect false positive in helper methods

### DIFF
--- a/src/rules/no-standalone-expect.ts
+++ b/src/rules/no-standalone-expect.ts
@@ -16,7 +16,7 @@ const getBlockType = (
 
   if (!func) {
     throw new Error(
-      `Unexpected BlockStatement. No parent defined. - please file a github issue at https://github.com/jest-community/eslint-plugin-jest`,
+      `Unexpected BlockStatement. No parent defined. - please file a github issue at https://github.com/playwright-community/eslint-plugin-playwright`,
     );
   }
 
@@ -29,7 +29,10 @@ const getBlockType = (
     const expr = func.parent;
 
     // arrow function or function expr
-    if (expr.type === 'VariableDeclarator') {
+    if (
+      expr.type === 'VariableDeclarator' ||
+      expr.type === 'MethodDefinition'
+    ) {
       return 'function';
     }
 

--- a/test/spec/no-standalone-expect.spec.ts
+++ b/test/spec/no-standalone-expect.spec.ts
@@ -74,6 +74,8 @@ runRuleTester('no-standalone-expect', rule, {
     '{}',
     'test.only("an only", value => { expect(value).toBe(true); });',
     'test.concurrent("an concurrent", value => { expect(value).toBe(true); });',
+    'class Helper { foo() { expect(1).toBe(1); } }',
+    'class Helper { foo = () => { expect(1).toBe(1); } }',
     // Global aliases
     {
       code: dedent`


### PR DESCRIPTION
This allows code such as the following to pass:

```ts
export class PageObjectModel {
  foo(x) {
    expect(x).toBeVisible();
  }
}
```