### PR TITLE
[noissue] Change from waitForUrl to waitForURL

### DIFF
--- a/docs/rules/no-wait-for-selector.md
+++ b/docs/rules/no-wait-for-selector.md
@@ -12,6 +12,6 @@ Examples of **correct** code for this rule:
 
 ```javascript
 await page.waitForLoadState();
-await page.waitForUrl('/home');
+await page.waitForURL('/home');
 await page.waitForFunction(() => window.innerWidth < 100);
 ```

--- a/docs/rules/no-wait-for-timeout.md
+++ b/docs/rules/no-wait-for-timeout.md
@@ -14,7 +14,7 @@ Examples of **correct** code for this rule:
 // Use signals such as network events, selectors becoming visible and others instead.
 await page.waitForLoadState();
 
-await page.waitForUrl('/home');
+await page.waitForURL('/home');
 
 await page.waitForFunction(() => window.innerWidth < 100);
 ```

--- a/src/rules/no-networkidle.test.ts
+++ b/src/rules/no-networkidle.test.ts
@@ -56,6 +56,6 @@ runRuleTester('no-networkidle', rule, {
 
     'this.page.waitForLoadState()',
     'page.waitForLoadState({ waitUntil: "load" })',
-    'page.waitForUrl(url, { waitUntil: "load" })',
+    'page.waitForURL(url, { waitUntil: "load" })',
   ],
 });

--- a/src/rules/no-useless-await.test.ts
+++ b/src/rules/no-useless-await.test.ts
@@ -193,7 +193,7 @@ runRuleTester('no-useless-await', rule, {
     'page.locator(".my-element")',
 
     'await page.waitForLoadState({ waitUntil: "load" })',
-    'await page.waitForUrl(url, { waitUntil: "load" })',
+    'await page.waitForURL(url, { waitUntil: "load" })',
     'await page.locator(".hello-world").waitFor()',
   ],
 });


### PR DESCRIPTION
Just fixed small typos of `waitForUrl` that does not exist.