### PR TITLE
feat: Add support for new test option syntax

### DIFF
--- a/src/rules/no-skipped-test.test.ts
+++ b/src/rules/no-skipped-test.test.ts
@@ -57,6 +57,23 @@ runRuleTester('no-skipped-test', rule, {
       ],
     },
     {
+      code: 'test.skip("a test", { tag: ["@fast", "@login"] }, () => {})',
+      errors: [
+        {
+          column: 6,
+          endColumn: 10,
+          line: 1,
+          messageId: 'noSkippedTest',
+          suggestions: [
+            {
+              messageId,
+              output: 'test("a test", { tag: ["@fast", "@login"] }, () => {})',
+            },
+          ],
+        },
+      ],
+    },
+    {
       code: 'test.describe.skip("skip this describe", () => {});',
       errors: [
         {
@@ -233,6 +250,8 @@ runRuleTester('no-skipped-test', rule, {
   ],
   valid: [
     'test("a test", () => {});',
+    'test("a test", { tag: "@fast" }, () => {});',
+    'test("a test", { tag: ["@fast", "@report"] }, () => {});',
     'test.describe("describe tests", () => {});',
     'test.describe.only("describe focus tests", () => {});',
     'test.describ["only"]("describe focus tests", () => {});',

--- a/src/rules/require-top-level-describe.test.ts
+++ b/src/rules/require-top-level-describe.test.ts
@@ -94,6 +94,12 @@ runRuleTester('require-top-level-describe', rule, {
       ],
     },
     {
+      code: 'test("foo", { tag: ["@fast"] }, () => {})',
+      errors: [
+        { column: 1, endColumn: 5, line: 1, messageId: 'unexpectedTest' },
+      ],
+    },
+    {
       code: dedent`
         test("foo", () => {})
         test.describe("suite", () => {});
@@ -209,6 +215,13 @@ runRuleTester('require-top-level-describe', rule, {
       test.describe('one', () => {});
       test.describe('two', () => {});
       test.describe('three', () => {});
+    `,
+    dedent`
+      test.describe("suite", () => {
+        test("foo", { tag: ["@slow"] }, () => {})
+        test.describe("another suite", { tag: ["@slow"] }, () => {});
+        test("my other test", () => {})
+      });
     `,
     {
       code: dedent`

--- a/src/utils/parseFnCall.test.ts
+++ b/src/utils/parseFnCall.test.ts
@@ -492,6 +492,57 @@ runRuleTester('test', rule, {
       ],
     },
     {
+      code: 'test("a test", { tag: ["@fast", "@login"] }, () => {});',
+      errors: [
+        {
+          column: 1,
+          data: expectedParsedFnCallResultData({
+            group: 'test',
+            head: {
+              local: 'test',
+              node: 'test',
+              original: null,
+            },
+            members: [],
+            name: 'test',
+            type: 'test',
+          }),
+          line: 1,
+          messageId: 'details',
+        },
+      ],
+    },
+    {
+      code: dedent`
+        test('test full report', {
+          annotation: [
+            { type: 'issue', description: 'https://github.com/microsoft/playwright/issues/23180' },
+            { type: 'docs', description: 'https://playwright.dev/docs/test-annotations#tag-tests' },
+          ],
+        }, async ({ page }) => {
+          // ...
+        });
+      `,
+      errors: [
+        {
+          column: 1,
+          data: expectedParsedFnCallResultData({
+            group: 'test',
+            head: {
+              local: 'test',
+              node: 'test',
+              original: null,
+            },
+            members: [],
+            name: 'test',
+            type: 'test',
+          }),
+          line: 1,
+          messageId: 'details',
+        },
+      ],
+    },
+    {
       code: 'test.step("a step", () => {});',
       errors: [
         {
@@ -854,6 +905,73 @@ runRuleTester('describe', rule, {
             type: 'describe',
           }),
           line: 1,
+          messageId: 'details',
+        },
+      ],
+    },
+    {
+      code: dedent`
+        test.describe('group', {
+          tag: '@report',
+        }, () => {
+          test('test report header', async ({ page }) => {
+            // ...
+          });
+
+          test('test full report', {
+            tag: ['@slow', '@vrt'],
+          }, async ({ page }) => {
+            // ...
+          });
+        });
+      `,
+      errors: [
+        {
+          column: 1,
+          data: expectedParsedFnCallResultData({
+            group: 'describe',
+            head: {
+              local: 'test',
+              node: 'test',
+              original: null,
+            },
+            members: ['describe'],
+            name: 'describe',
+            type: 'describe',
+          }),
+          line: 1,
+          messageId: 'details',
+        },
+        {
+          column: 3,
+          data: expectedParsedFnCallResultData({
+            group: 'test',
+            head: {
+              local: 'test',
+              node: 'test',
+              original: null,
+            },
+            members: [],
+            name: 'test',
+            type: 'test',
+          }),
+          line: 4,
+          messageId: 'details',
+        },
+        {
+          column: 3,
+          data: expectedParsedFnCallResultData({
+            group: 'test',
+            head: {
+              local: 'test',
+              node: 'test',
+              original: null,
+            },
+            members: [],
+            name: 'test',
+            type: 'test',
+          }),
+          line: 8,
           messageId: 'details',
         },
       ],

--- a/src/utils/parseFnCall.ts
+++ b/src/utils/parseFnCall.ts
@@ -400,7 +400,7 @@ function parse(
   let type: FnType = group;
   if (
     (name === 'test' || name === 'describe') &&
-    (node.arguments.length !== 2 || !isFunction(node.arguments[1]))
+    (node.arguments.length < 2 || !isFunction(node.arguments.at(-1)))
   ) {
     type = 'config';
   }


### PR DESCRIPTION
Fixes #263 

https://playwright.dev/docs/test-annotations#tag-tests

```ts
import { test, expect } from '@playwright/test';

test('test login page', {
  tag: '@fast',
}, async ({ page }) => {
  // ...
});

test('test full report @slow', async ({ page }) => {
  // ...
});
```