### PR TITLE
Preserve rule type constants

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -100,31 +100,31 @@ const index = {
 
 const sharedConfig = {
   rules: {
-    'no-empty-pattern': 'off',
-    'playwright/expect-expect': 'warn',
-    'playwright/max-nested-describe': 'warn',
-    'playwright/missing-playwright-await': 'error',
-    'playwright/no-conditional-expect': 'warn',
-    'playwright/no-conditional-in-test': 'warn',
-    'playwright/no-element-handle': 'warn',
-    'playwright/no-eval': 'warn',
-    'playwright/no-focused-test': 'error',
-    'playwright/no-force-option': 'warn',
-    'playwright/no-nested-step': 'warn',
-    'playwright/no-networkidle': 'error',
-    'playwright/no-page-pause': 'warn',
-    'playwright/no-skipped-test': 'warn',
-    'playwright/no-standalone-expect': 'error',
-    'playwright/no-unsafe-references': 'error',
-    'playwright/no-useless-await': 'warn',
-    'playwright/no-useless-not': 'warn',
-    'playwright/no-wait-for-selector': 'warn',
-    'playwright/no-wait-for-timeout': 'warn',
-    'playwright/prefer-web-first-assertions': 'error',
-    'playwright/valid-describe-callback': 'error',
-    'playwright/valid-expect': 'error',
-    'playwright/valid-expect-in-promise': 'error',
-    'playwright/valid-title': 'error',
+    'no-empty-pattern': 'off' as const,
+    'playwright/expect-expect': 'warn' as const,
+    'playwright/max-nested-describe': 'warn' as const,
+    'playwright/missing-playwright-await': 'error' as const,
+    'playwright/no-conditional-expect': 'warn' as const,
+    'playwright/no-conditional-in-test': 'warn' as const,
+    'playwright/no-element-handle': 'warn' as const,
+    'playwright/no-eval': 'warn' as const,
+    'playwright/no-focused-test': 'error' as const,
+    'playwright/no-force-option': 'warn' as const,
+    'playwright/no-nested-step': 'warn' as const,
+    'playwright/no-networkidle': 'error' as const,
+    'playwright/no-page-pause': 'warn' as const,
+    'playwright/no-skipped-test': 'warn' as const,
+    'playwright/no-standalone-expect': 'error' as const,
+    'playwright/no-unsafe-references': 'error' as const,
+    'playwright/no-useless-await': 'warn' as const,
+    'playwright/no-useless-not': 'warn' as const,
+    'playwright/no-wait-for-selector': 'warn' as const,
+    'playwright/no-wait-for-timeout': 'warn' as const,
+    'playwright/prefer-web-first-assertions': 'error' as const,
+    'playwright/valid-describe-callback': 'error' as const,
+    'playwright/valid-expect': 'error' as const,
+    'playwright/valid-expect-in-promise': 'error' as const,
+    'playwright/valid-title': 'error' as const,
   },
 }
 
@@ -149,7 +149,7 @@ const flatConfig = {
 const sharedJestConfig = {
   rules: {
     'jest/no-standalone-expect': [
-      'error',
+      'error' as const,
       {
         additionalTestBlockFunctions: [
           'test.jestPlaywrightDebug',
@@ -161,8 +161,8 @@ const sharedJestConfig = {
         ],
       },
     ],
-    'playwright/missing-playwright-await': 'error',
-    'playwright/no-page-pause': 'warn',
+    'playwright/missing-playwright-await': 'error' as const,
+    'playwright/no-page-pause': 'warn' as const,
   },
 }
 


### PR DESCRIPTION
I was having a type error when using this plugin:

```
Type '{ 'playwright/no-commented-out-tests': "error"; 'playwright/no-duplicate-hooks': "error"; 'playwright/prefer-hooks-on-top': "error"; 'no-only-tests/no-only-tests': "error"; 'no-empty-pattern': string; ... 23 more ...; 'playwright/valid-title': string; }' is not assignable to type 'RulesRecord'.
  Property ''no-empty-pattern'' is incompatible with index signature.
    Type 'string' is not assignable to type 'RuleEntry<any[]>'.ts(2322)
index.d.ts(1307, 9): The expected type comes from property 'rules' which is declared here on type 'FlatConfig'
```

This is because the generated type for the rules was just `string`, rather than an explicit `"off"` or `"warn"` or `"error"`, so I added `as const` to those strings so that they would stay in the generated .d.ts types.

before:
```ts
            rules: {
                'no-empty-pattern': string;
                'playwright/expect-expect': string;
                'playwright/max-nested-describe': string;
                'playwright/missing-playwright-await': string;
                'playwright/no-conditional-expect': string;
                'playwright/no-conditional-in-test': string;
                'playwright/no-element-handle': string;
                'playwright/no-eval': string;
                'playwright/no-focused-test': string;
                'playwright/no-force-option': string;
                'playwright/no-nested-step': string;
                'playwright/no-networkidle': string;
                'playwright/no-page-pause': string;
                'playwright/no-skipped-test': string;
                'playwright/no-standalone-expect': string;
                'playwright/no-unsafe-references': string;
                'playwright/no-useless-await': string;
                'playwright/no-useless-not': string;
                'playwright/no-wait-for-selector': string;
                'playwright/no-wait-for-timeout': string;
                'playwright/prefer-web-first-assertions': string;
                'playwright/valid-describe-callback': string;
                'playwright/valid-expect': string;
                'playwright/valid-expect-in-promise': string;
                'playwright/valid-title': string;
            };
```

after:
```ts
            rules: {
                'no-empty-pattern': "off";
                'playwright/expect-expect': "warn";
                'playwright/max-nested-describe': "warn";
                'playwright/missing-playwright-await': "error";
                'playwright/no-conditional-expect': "warn";
                'playwright/no-conditional-in-test': "warn";
                'playwright/no-element-handle': "warn";
                'playwright/no-eval': "warn";
                'playwright/no-focused-test': "error";
                'playwright/no-force-option': "warn";
                'playwright/no-nested-step': "warn";
                'playwright/no-networkidle': "error";
                'playwright/no-page-pause': "warn";
                'playwright/no-skipped-test': "warn";
                'playwright/no-standalone-expect': "error";
                'playwright/no-unsafe-references': "error";
                'playwright/no-useless-await': "warn";
                'playwright/no-useless-not': "warn";
                'playwright/no-wait-for-selector': "warn";
                'playwright/no-wait-for-timeout': "warn";
                'playwright/prefer-web-first-assertions': "error";
                'playwright/valid-describe-callback': "error";
                'playwright/valid-expect': "error";
                'playwright/valid-expect-in-promise': "error";
                'playwright/valid-title': "error";
            };
```