### PR TITLE
feat: Include justification and alternatives in the message for many rules

### DIFF
--- a/src/rules/no-conditional-expect.ts
+++ b/src/rules/no-conditional-expect.ts
@@ -105,7 +105,7 @@ export default {
       url: 'https://github.com/playwright-community/eslint-plugin-playwright/tree/main/docs/rules/no-conditional-expect.md',
     },
     messages: {
-      conditionalExpect: 'Avoid calling `expect` conditionally`',
+      conditionalExpect: 'Avoid calling `expect` conditionally, as tests can end up passing but not actually test anything.',
     },
     type: 'problem',
   },

--- a/src/rules/no-focused-test.ts
+++ b/src/rules/no-focused-test.ts
@@ -42,8 +42,8 @@ export default {
     },
     hasSuggestions: true,
     messages: {
-      noFocusedTest: 'Unexpected focused test.',
-      suggestRemoveOnly: 'Remove .only() annotation.',
+      noFocusedTest: 'Unexpected focused test. Other tests in this block will not be run.',
+      suggestRemoveOnly: 'Remove `.only()` annotation.',
     },
     type: 'problem',
   },

--- a/src/rules/no-force-option.ts
+++ b/src/rules/no-force-option.ts
@@ -56,7 +56,7 @@ export default {
       url: 'https://github.com/playwright-community/eslint-plugin-playwright/tree/main/docs/rules/no-force-option.md',
     },
     messages: {
-      noForceOption: 'Unexpected use of { force: true } option.',
+      noForceOption: 'Unexpected use of `{ force: true }`. This bypasses actionability checks like the element\'s visibility.',
     },
     type: 'suggestion',
   },

--- a/src/rules/no-hooks.ts
+++ b/src/rules/no-hooks.ts
@@ -31,7 +31,7 @@ export default {
       url: 'https://github.com/playwright-community/eslint-plugin-playwright/tree/main/docs/rules/no-hooks.md',
     },
     messages: {
-      unexpectedHook: "Unexpected '{{ hookName }}' hook",
+      unexpectedHook: "Unexpected '{{ hookName }}' hook. The use of these hooks may result in shared state between tests.",
     },
     schema: [
       {

--- a/src/rules/no-networkidle.ts
+++ b/src/rules/no-networkidle.ts
@@ -57,7 +57,7 @@ export default {
       url: 'https://github.com/playwright-community/eslint-plugin-playwright/tree/main/docs/rules/no-networkidle.md',
     },
     messages: {
-      noNetworkidle: 'Unexpected use of networkidle.',
+      noNetworkidle: 'Using networkidle is discouraged. Use web first assertions like waiting for text to be visible instead.',
     },
     type: 'problem',
   },

--- a/src/rules/no-nth-methods.ts
+++ b/src/rules/no-nth-methods.ts
@@ -31,7 +31,7 @@ export default {
       url: 'https://github.com/playwright-community/eslint-plugin-playwright/tree/main/docs/rules/no-nth-methods.md',
     },
     messages: {
-      noNthMethod: 'Unexpected use of {{method}}()',
+      noNthMethod: 'Use of {{method}}() is discouraged. These methods can be prone to flakiness if the DOM structure changes.',
     },
     type: 'problem',
   },

--- a/src/rules/no-page-pause.ts
+++ b/src/rules/no-page-pause.ts
@@ -19,7 +19,7 @@ export default {
       url: 'https://github.com/playwright-community/eslint-plugin-playwright/tree/main/docs/rules/no-page-pause.md',
     },
     messages: {
-      noPagePause: 'Unexpected use of page.pause().',
+      noPagePause: 'Unexpected use of page.pause(). This method requires Playwright to be started in a headed mode.',
     },
     type: 'problem',
   },

--- a/src/rules/no-unsafe-references.ts
+++ b/src/rules/no-unsafe-references.ts
@@ -149,7 +149,7 @@ export default {
     fixable: 'code',
     messages: {
       noUnsafeReference:
-        'Unsafe reference to variable "{{ variable }}" in page.evaluate()',
+        'Unsafe reference to variable "{{ variable }}" in `page.evaluate()`. You must pass used variables as arguments to `page.evaluate()`.',
     },
     type: 'problem',
   },

--- a/src/rules/no-wait-for-selector.ts
+++ b/src/rules/no-wait-for-selector.ts
@@ -34,8 +34,8 @@ export default {
     },
     hasSuggestions: true,
     messages: {
-      noWaitForSelector: 'Unexpected use of page.waitForSelector().',
-      removeWaitForSelector: 'Remove the page.waitForSelector() method.',
+      noWaitForSelector: 'Unexpected use of `page.waitForSelector()`. Use web assertions that assert visibility or a locator-based `locator.waitFor()` instead, or remove the call.',
+      removeWaitForSelector: 'Remove the `page.waitForSelector()` call.',
     },
     type: 'suggestion',
   },

--- a/src/rules/no-wait-for-timeout.ts
+++ b/src/rules/no-wait-for-timeout.ts
@@ -34,7 +34,7 @@ export default {
     },
     hasSuggestions: true,
     messages: {
-      noWaitForTimeout: 'Unexpected use of page.waitForTimeout().',
+      noWaitForTimeout: 'Never wait for timeout in production. Tests that wait for time are inherently flaky. Use Locator actions and web assertions that wait automatically, or remove the wait.',
       removeWaitForTimeout: 'Remove the page.waitForTimeout() method.',
     },
     type: 'suggestion',

--- a/src/rules/prefer-comparison-matcher.ts
+++ b/src/rules/prefer-comparison-matcher.ts
@@ -115,11 +115,11 @@ export default {
       category: 'Best Practices',
       description: 'Suggest using the built-in comparison matchers',
       recommended: false,
-      url: 'https://github.com/playwright-community/eslint-plugin-playwright/tree/main/docs/rules/prefer-comparision-matcher.md',
+      url: 'https://github.com/playwright-community/eslint-plugin-playwright/tree/main/docs/rules/prefer-comparison-matcher.md',
     },
     fixable: 'code',
     messages: {
-      useToBeComparison: 'Prefer using `{{ preferredMatcher }}` instead',
+      useToBeComparison: 'Playwright has a number of built-in matchers for comparing numbers. Prefer using `{{ preferredMatcher }}` instead.',
     },
     type: 'suggestion',
   },

--- a/src/rules/prefer-equality-matcher.ts
+++ b/src/rules/prefer-equality-matcher.ts
@@ -93,7 +93,7 @@ export default {
     hasSuggestions: true,
     messages: {
       suggestEqualityMatcher: 'Use `{{ matcher }}`',
-      useEqualityMatcher: 'Prefer using one of the equality matchers instead',
+      useEqualityMatcher: 'Playwright has built-in matchers for expecting equality. Prefer using one of the equality matchers instead.',
     },
     type: 'suggestion',
   },

--- a/src/rules/prefer-strict-equal.ts
+++ b/src/rules/prefer-strict-equal.ts
@@ -41,7 +41,7 @@ export default {
     hasSuggestions: true,
     messages: {
       suggestReplaceWithStrictEqual: 'Replace with `toStrictEqual()`',
-      useToStrictEqual: 'Use toStrictEqual() instead',
+      useToStrictEqual: 'Stricter equality will catch cases where two objects do not have identical keys. Use `toStrictEqual()` instead.',
     },
     schema: [],
     type: 'suggestion',

--- a/src/rules/prefer-to-contain.ts
+++ b/src/rules/prefer-to-contain.ts
@@ -102,7 +102,7 @@ export default {
     },
     fixable: 'code',
     messages: {
-      useToContain: 'Use toContain() instead',
+      useToContain: 'To have a better failure message, use `toContain()` instead.',
     },
     type: 'suggestion',
   },

--- a/src/rules/prefer-to-have-count.ts
+++ b/src/rules/prefer-to-have-count.ts
@@ -60,7 +60,7 @@ export default {
     },
     fixable: 'code',
     messages: {
-      useToHaveCount: 'Use toHaveCount() instead',
+      useToHaveCount: 'To have a better failure message, use `toHaveCount()` instead.',
     },
     schema: [],
     type: 'suggestion',

--- a/src/rules/prefer-to-have-length.ts
+++ b/src/rules/prefer-to-have-length.ts
@@ -50,7 +50,7 @@ export default {
     },
     fixable: 'code',
     messages: {
-      useToHaveLength: 'Use toHaveLength() instead',
+      useToHaveLength: 'To have a better failure message, use `toHaveLength()` instead.',
     },
     schema: [],
     type: 'suggestion',

--- a/src/rules/require-hook.ts
+++ b/src/rules/require-hook.ts
@@ -82,7 +82,7 @@ export default {
       url: 'https://github.com/playwright-community/eslint-plugin-playwright/tree/main/docs/rules/require-hook.md',
     },
     messages: {
-      useHook: 'This should be done within a hook',
+      useHook: 'Setup and teardown code should be done within a hook like `beforeEach()`.',
     },
     schema: [
       {

--- a/src/rules/require-to-throw-message.ts
+++ b/src/rules/require-to-throw-message.ts
@@ -32,7 +32,7 @@ export default {
       url: 'https://github.com/playwright-community/eslint-plugin-playwright/tree/main/docs/rules/require-to-throw-message.md',
     },
     messages: {
-      addErrorMessage: 'Add an error message to {{ matcherName }}()',
+      addErrorMessage: 'If no message is defined, the test will pass for any thrown error. Add an error message to {{ matcherName }}().',
     },
     schema: [],
     type: 'suggestion',


### PR DESCRIPTION
Many rules in `eslint-plugin-playwright` have very terse lint messages, [ex. no-wait-for-timeout](https://github.com/playwright-community/eslint-plugin-playwright/blob/main/src/rules/no-wait-for-timeout.ts#L37). Instead of providing more context in the lint message, the rules rely on the documentation linked in `meta.docs`.  For users who are less familiar with Playwright, messages as terse as "unexpected use of X" doesn't provide an understanding of the severity of the problems or alternatives they could pursue. Compounding the problem, lint execution outside IDE environments (ex. in CI) doesn't surface the links in each rule's `meta.docs` object to the user, reducing context further.

Contrast this approach with the approach taken by projects like [@angular-eslint/eslint-plugin](https://github.com/angular-eslint/angular-eslint/blob/main/packages/eslint-plugin/src/rules/no-attribute-decorator.ts), where messages are still short, but some justification and alternatives are presented in-message. Even many of eslint's built-in rules include either alternatives or custom messages that allow eslint users to provide additional context when the message is raised, ex. [no-restricted-imports](https://eslint.org/docs/latest/rules/no-restricted-imports#options).
    
This PR updates many rules to provide at least a little justification and alternative context in each lint message. While I was here, I noticed that many messages in the repo differ on whether or not they include the final punctuation, so on lines I touched, I also standardized on using final punctuation to match eslint's built-in rules, [ex. arrow-body-style](https://github.com/eslint/eslint/blob/main/lib/rules/arrow-body-style.js#L63).

Tests pass:
```
$ pnpm test
...

 Test Files  48 passed (48)
      Tests  2393 passed (2393)
   Start at  15:56:08
   Duration  4.21s (transform 1.81s, setup 3ms, collect 6.70s, tests 4.34s, environment 5ms, prepare 3.49s)


 PASS  Waiting for file changes...
       press h to show help, press q to quit
```