### PR TITLE
docs: fix usage guide flat recommended rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ import playwright from 'eslint-plugin-playwright'
 
 export default [
   {
-    ...playwright.configs['flat/playwright'],
+    ...playwright.configs['flat/recommended'],
     files: ['tests/**'],
   },
   {


### PR DESCRIPTION
`flat/playwright` does not exist as described in the documentation README file.

I changed to `flat/recommended`.