### PR TITLE
Strict Typing

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,4 @@
+import { ESLint, Linter } from 'eslint'
 import globals from 'globals'
 import expectExpect from './rules/expect-expect'
 import maxExpects from './rules/max-expects'
@@ -96,7 +97,7 @@ const index = {
     'valid-expect-in-promise': validExpectInPromise,
     'valid-title': validTitle,
   },
-}
+} as const satisfies ESLint.Plugin
 
 const sharedConfig = {
   rules: {
@@ -126,7 +127,7 @@ const sharedConfig = {
     'playwright/valid-expect-in-promise': 'error',
     'playwright/valid-title': 'error',
   },
-} as const
+} as const satisfies Linter.FlatConfig
 
 const legacyConfig = {
   ...sharedConfig,
@@ -134,7 +135,7 @@ const legacyConfig = {
     'shared-node-browser': true,
   },
   plugins: ['playwright'],
-}
+} as const satisfies Linter.BaseConfig
 
 const flatConfig = {
   ...sharedConfig,
@@ -144,7 +145,7 @@ const flatConfig = {
   plugins: {
     playwright: index,
   },
-}
+} as const satisfies Linter.FlatConfig
 
 const sharedJestConfig = {
   rules: {
@@ -164,7 +165,7 @@ const sharedJestConfig = {
     'playwright/missing-playwright-await': 'error',
     'playwright/no-page-pause': 'warn',
   },
-} as const
+} as const satisfies Linter.FlatConfig
 
 const legacyJestConfig = {
   ...sharedJestConfig,
@@ -181,7 +182,7 @@ const legacyJestConfig = {
     page: true,
   },
   plugins: ['jest', 'playwright'],
-}
+} as const satisfies Linter.BaseConfig
 
 const jestConfig = {
   ...sharedJestConfig,
@@ -200,7 +201,7 @@ const jestConfig = {
   plugins: {
     playwright: index,
   },
-}
+} as const satisfies Linter.FlatConfig
 
 export = {
   ...index,

--- a/src/rules/expect-expect.ts
+++ b/src/rules/expect-expect.ts
@@ -8,7 +8,7 @@ export default createRule({
     const options = {
       assertFunctionNames: [] as string[],
       ...((context.options?.[0] as Record<string, unknown>) ?? {}),
-    }
+    } as const
 
     const unchecked: ESTree.CallExpression[] = []
 

--- a/src/rules/max-expects.ts
+++ b/src/rules/max-expects.ts
@@ -8,7 +8,7 @@ export default createRule({
     const options = {
       max: 5,
       ...((context.options?.[0] as Record<string, unknown>) ?? {}),
-    }
+    } as const
 
     let count = 0
 

--- a/src/rules/missing-playwright-await.ts
+++ b/src/rules/missing-playwright-await.ts
@@ -28,7 +28,7 @@ const expectPlaywrightMatchers = [
   'toMatchURL',
   'toMatchValue',
   'toPass',
-]
+] as const satisfies string[]
 
 const playwrightTestMatchers = [
   'toBeChecked',
@@ -55,7 +55,7 @@ const playwrightTestMatchers = [
   'toHaveValues',
   'toBeAttached',
   'toBeInViewport',
-]
+] as const satisfies string[]
 
 function getReportNode(node: ESTree.Node) {
   const parent = getParent(node)

--- a/src/rules/no-conditional-expect.ts
+++ b/src/rules/no-conditional-expect.ts
@@ -15,7 +15,7 @@ const getTestCallExpressionsFromDeclaredVariables = (
   context: Rule.RuleContext,
   declaredVariables: readonly Scope.Variable[],
 ): ESTree.CallExpression[] => {
-  return declaredVariables.reduce(
+  return declaredVariables.reduce<ESTree.CallExpression[]>(
     (acc, { references }) => [
       ...acc,
       ...references
@@ -27,7 +27,7 @@ const getTestCallExpressionsFromDeclaredVariables = (
             isTypeOfFnCall(context, node, ['test']),
         ),
     ],
-    [] as ESTree.CallExpression[],
+    [],
   )
 }
 

--- a/src/rules/no-hooks.ts
+++ b/src/rules/no-hooks.ts
@@ -6,7 +6,7 @@ export default createRule({
     const options = {
       allow: [] as string[],
       ...((context.options?.[0] as Record<string, unknown>) ?? {}),
-    }
+    } as const
 
     return {
       CallExpression(node) {

--- a/src/rules/no-raw-locators.ts
+++ b/src/rules/no-raw-locators.ts
@@ -12,7 +12,7 @@ export default createRule({
     const options = {
       allowed: [] as string[],
       ...((context.options?.[0] as Record<string, unknown>) ?? {}),
-    }
+    } as const
 
     function isAllowed(arg: string) {
       return options.allowed.some((a) => normalize(a) === normalize(arg))

--- a/src/rules/no-restricted-matchers.ts
+++ b/src/rules/no-restricted-matchers.ts
@@ -4,9 +4,8 @@ import { parseFnCall } from '../utils/parseFnCall'
 
 export default createRule({
   create(context) {
-    const restrictedChains = (context.options?.[0] ?? {}) as {
-      [key: string]: string | null
-    }
+    const restrictedChains: Record<string, string | null> =
+      context.options?.[0] ?? {}
 
     return {
       CallExpression(node) {

--- a/src/rules/require-hook.ts
+++ b/src/rules/require-hook.ts
@@ -44,7 +44,7 @@ export default createRule({
     const options = {
       allowedFunctionCalls: [] as string[],
       ...((context.options?.[0] as Record<string, unknown>) ?? {}),
-    }
+    } as const
 
     const checkBlockBody = (body: ESTree.Program['body']) => {
       for (const statement of body) {

--- a/src/rules/valid-expect.ts
+++ b/src/rules/valid-expect.ts
@@ -32,7 +32,7 @@ export default createRule({
       maxArgs: 2,
       minArgs: 1,
       ...((context.options?.[0] as Record<string, unknown>) ?? {}),
-    }
+    } as const
 
     const minArgs = Math.min(options.minArgs, options.maxArgs)
     const maxArgs = Math.max(options.minArgs, options.maxArgs)

--- a/src/rules/valid-title.ts
+++ b/src/rules/valid-title.ts
@@ -86,7 +86,6 @@ interface Options {
 
 export default createRule({
   create(context) {
-    const opts: Options = context.options?.[0] ?? {}
     const {
       disallowedWords = [],
       ignoreSpaces = false,
@@ -94,7 +93,7 @@ export default createRule({
       ignoreTypeOfTestName = false,
       mustMatch,
       mustNotMatch,
-    } = opts
+    }: Options = context.options?.[0] ?? {}
     const disallowedWordsRegexp = new RegExp(
       `\\b(${disallowedWords.join('|')})\\b`,
       'iu',


### PR DESCRIPTION
I apologize for the sudden PR, but I'd like to propose some strict typing enhancements.
Please consider the following changes:

- Applied 'as const' specifier for stricter typing.
- Utilized 'satisfies' to enforce type constraints.
- Refactored to use generics instead of type assertions in reduce function.