### PR TITLE
Fix prefer-to-have-count rule for expect arguments that need dereferencing  

### DIFF
--- a/src/rules/prefer-to-have-count.test.ts
+++ b/src/rules/prefer-to-have-count.test.ts
@@ -72,6 +72,109 @@ runRuleTester('prefer-to-have-count', rule, {
         },
       },
     },
+    {
+      code: `
+        const filesCount = await files.count();
+        expect(filesCount).toBe(1)
+      `,
+      errors: [
+        { column: 28, endColumn: 32, line: 3, messageId: 'useToHaveCount' },
+      ],
+      output: `
+        const filesCount = files;
+        await expect(filesCount).toHaveCount(1)
+      `,
+      settings: {
+        playwright: {
+          globalAliases: { expect: ['assert'] },
+        },
+      },
+    },
+    {
+      code: `
+        const filesCount = await files.count();
+        const unrelatedConst = unrelated;
+        expect(filesCount).toBe(1)
+      `,
+      errors: [
+        { column: 28, endColumn: 32, line: 4, messageId: 'useToHaveCount' },
+      ],
+      output: `
+        const filesCount = files;
+        const unrelatedConst = unrelated;
+        await expect(filesCount).toHaveCount(1)
+      `,
+      settings: {
+        playwright: {
+          globalAliases: { expect: ['assert'] },
+        },
+      },
+    },
+    {
+      code: `
+        let filesCount = 3;
+        filesCount = await files.count();
+        expect(filesCount).toBe(1);
+      `,
+      errors: [
+        { column: 28, endColumn: 32, line: 4, messageId: 'useToHaveCount' },
+      ],
+      output: `
+        let filesCount = 3;
+        filesCount = files;
+        await expect(filesCount).toHaveCount(1);
+      `,
+      settings: {
+        playwright: {
+          globalAliases: { expect: ['assert'] },
+        },
+      },
+    },
+    {
+      code: `
+        let filesCount = 3;
+        filesCount = await files.count();
+        let unrelatedVar = unrelated;
+        expect(filesCount).toBe(1);
+      `,
+      errors: [
+        { column: 28, endColumn: 32, line: 5, messageId: 'useToHaveCount' },
+      ],
+      output: `
+        let filesCount = 3;
+        filesCount = files;
+        let unrelatedVar = unrelated;
+        await expect(filesCount).toHaveCount(1);
+      `,
+      settings: {
+        playwright: {
+          globalAliases: { expect: ['assert'] },
+        },
+      },
+    },
+    {
+      code: `
+        let filesCount = 3;
+        filesCount = await files.count();
+        expect(filesCount).toBe(1);
+        filesCount = 0;
+      `,
+      errors: [
+        { column: 28, endColumn: 32, line: 4, messageId: 'useToHaveCount' },
+      ],
+      output: `
+        let filesCount = 3;
+        filesCount = files;
+        await expect(filesCount).toHaveCount(1);
+        filesCount = 0;
+      `,
+      settings: {
+        playwright: {
+          globalAliases: { expect: ['assert'] },
+        },
+      },
+    },
+    
   ],
   valid: [
     { code: 'await expect(files).toHaveCount(1)' },

--- a/src/rules/prefer-to-have-count.test.ts
+++ b/src/rules/prefer-to-have-count.test.ts
@@ -84,11 +84,6 @@ runRuleTester('prefer-to-have-count', rule, {
         const filesCount = files;
         await expect(filesCount).toHaveCount(1)
       `,
-      settings: {
-        playwright: {
-          globalAliases: { expect: ['assert'] },
-        },
-      },
     },
     {
       code: `
@@ -104,11 +99,6 @@ runRuleTester('prefer-to-have-count', rule, {
         const unrelatedConst = unrelated;
         await expect(filesCount).toHaveCount(1)
       `,
-      settings: {
-        playwright: {
-          globalAliases: { expect: ['assert'] },
-        },
-      },
     },
     {
       code: `
@@ -124,11 +114,6 @@ runRuleTester('prefer-to-have-count', rule, {
         filesCount = files;
         await expect(filesCount).toHaveCount(1);
       `,
-      settings: {
-        playwright: {
-          globalAliases: { expect: ['assert'] },
-        },
-      },
     },
     {
       code: `
@@ -146,11 +131,6 @@ runRuleTester('prefer-to-have-count', rule, {
         let unrelatedVar = unrelated;
         await expect(filesCount).toHaveCount(1);
       `,
-      settings: {
-        playwright: {
-          globalAliases: { expect: ['assert'] },
-        },
-      },
     },
     {
       code: `
@@ -168,13 +148,7 @@ runRuleTester('prefer-to-have-count', rule, {
         await expect(filesCount).toHaveCount(1);
         filesCount = 0;
       `,
-      settings: {
-        playwright: {
-          globalAliases: { expect: ['assert'] },
-        },
-      },
     },
-    
   ],
   valid: [
     { code: 'await expect(files).toHaveCount(1)' },

--- a/src/rules/prefer-to-have-count.ts
+++ b/src/rules/prefer-to-have-count.ts
@@ -1,4 +1,4 @@
-import { equalityMatchers, isPropertyAccessor } from '../utils/ast'
+import { dereference, equalityMatchers, isPropertyAccessor } from '../utils/ast'
 import { createRule } from '../utils/createRule'
 import { replaceAccessorFixer } from '../utils/fixer'
 import { parseFnCall } from '../utils/parseFnCall'
@@ -15,7 +15,7 @@ export default createRule({
           return
         }
 
-        const [argument] = call.args
+        const argument = dereference(context, call.args[0])
         if (
           argument?.type !== 'AwaitExpression' ||
           argument.argument.type !== 'CallExpression' ||

--- a/src/rules/prefer-web-first-assertions.ts
+++ b/src/rules/prefer-web-first-assertions.ts
@@ -1,6 +1,5 @@
-import { Rule } from 'eslint'
-import ESTree, { AssignmentExpression } from 'estree'
 import {
+  dereference,
   findParent,
   getRawValue,
   getStringValue,
@@ -8,7 +7,6 @@ import {
 } from '../utils/ast'
 import { createRule } from '../utils/createRule'
 import { parseFnCall } from '../utils/parseFnCall'
-import { TypedNodeWithParent } from '../utils/types'
 
 type MethodConfig = {
   inverse?: string
@@ -59,77 +57,6 @@ const supportedMatchers = new Set([
   'toBeTruthy',
   'toBeFalsy',
 ])
-
-const isVariableDeclarator = (
-  node: ESTree.Node,
-): node is TypedNodeWithParent<'VariableDeclarator'> =>
-  node.type === 'VariableDeclarator'
-
-const isAssignmentExpression = (
-  node: ESTree.Node,
-): node is TypedNodeWithParent<'AssignmentExpression'> =>
-  node.type === 'AssignmentExpression'
-
-/**
- * Given a Node and an assignment expression, finds out if the assignment
- * expression happens before the node identifier (based on their range
- * properties) and if the assignment expression left side is of the same name as
- * the name of the given node.
- *
- * @param node The node we are comparing the assignment expression to.
- * @param assignment The assignment that will be verified to see if its left
- *   operand is the same as the node.name and if it happens before it.
- * @returns True if the assignment left hand operator belongs to the node and
- *   occurs before it, false otherwise. If either the node or the assignment
- *   expression doesn't contain a range array, this will also return false
- *   because their relative positions cannot be calculated.
- */
-function isNodeLastAssignment(
-  node: ESTree.Identifier,
-  assignment: AssignmentExpression,
-) {
-  if (node.range && assignment.range && node.range[0] < assignment.range[1]) {
-    return false
-  }
-
-  return (
-    assignment.left.type === 'Identifier' && assignment.left.name === node.name
-  )
-}
-
-/**
- * If the expect call argument is a variable reference, finds the variable
- * initializer or last variable assignment.
- *
- * If a variable is assigned after initialization we have to look for the last
- * time it was assigned because it could have been changed multiple times. We
- * then use its right hand assignment operator as the dereferenced node.
- */
-function dereference(context: Rule.RuleContext, node: ESTree.Node | undefined) {
-  if (node?.type !== 'Identifier') {
-    return node
-  }
-
-  const scope = context.sourceCode.getScope(node)
-  const parents = scope.references
-    .map((ref) => ref.identifier as Rule.Node)
-    .map((ident) => ident.parent)
-
-  // Look for any variable declarators in the scope references that match the
-  // dereferenced node variable name
-  const decl = parents
-    .filter(isVariableDeclarator)
-    .find((p) => p.id.type === 'Identifier' && p.id.name === node.name)
-
-  // Look for any variable assignments in the scope references and pick the last
-  // one that matches the dereferenced node variable name
-  const expr = parents
-    .filter(isAssignmentExpression)
-    .reverse()
-    .find((assignment) => isNodeLastAssignment(node, assignment))
-
-  return expr?.right ?? decl?.init
-}
 
 export default createRule({
   create(context) {

--- a/src/utils/ast.ts
+++ b/src/utils/ast.ts
@@ -9,10 +9,10 @@ export function getStringValue(node: ESTree.Node | undefined) {
   return node.type === 'Identifier'
     ? node.name
     : node.type === 'TemplateLiteral'
-    ? node.quasis[0].value.raw
-    : node.type === 'Literal' && typeof node.value === 'string'
-    ? node.value
-    : ''
+      ? node.quasis[0].value.raw
+      : node.type === 'Literal' && typeof node.value === 'string'
+        ? node.value
+        : ''
 }
 
 export function getRawValue(node: ESTree.Node) {
@@ -106,10 +106,10 @@ export function dig(node: ESTree.Node, identifier: string | RegExp): boolean {
   return node.type === 'MemberExpression'
     ? dig(node.property, identifier)
     : node.type === 'CallExpression'
-    ? dig(node.callee, identifier)
-    : node.type === 'Identifier'
-    ? isIdentifier(node, identifier)
-    : false
+      ? dig(node.callee, identifier)
+      : node.type === 'Identifier'
+        ? isIdentifier(node, identifier)
+        : false
 }
 
 export function isPageMethod(node: ESTree.CallExpression, name: string) {
@@ -168,7 +168,7 @@ const isAssignmentExpression = (
   node: ESTree.Node,
 ): node is TypedNodeWithParent<'AssignmentExpression'> =>
   node.type === 'AssignmentExpression'
-  
+
 /**
  * Given a Node and an assignment expression, finds out if the assignment
  * expression happens before the node identifier (based on their range
@@ -197,25 +197,28 @@ function isNodeLastAssignment(
 }
 
 /**
- * If the node argument is a variable reference, finds the variable
- * initializer or last variable assignment and returns the assigned value.
+ * If the node argument is a variable reference, finds the variable initializer
+ * or last variable assignment and returns the assigned value.
  *
  * If a variable is assigned after initialization we have to look for the last
  * time it was assigned because it could have been changed multiple times. We
  * then use its right hand assignment operator as the dereferenced node.
- * 
+ *
  * @example <caption>Dereference a `const` initialized node:</caption>
- * // returns 1
- * const variable = 1;
- * console.log(variable) // dereferenced value of the 'variable' node is 1
- *  
+ *   // returns 1
+ *   const variable = 1
+ *   console.log(variable) // dereferenced value of the 'variable' node is 1
+ *
  * @example <caption>Dereference a `let` re-assigned node:</caption>
- * // returns 1
- * let variable = 0;
- * variable = 1;
- * console.log(variable) // dereferenced value of the 'variable' node is 1
+ *   // returns 1
+ *   let variable = 0
+ *   variable = 1
+ *   console.log(variable) // dereferenced value of the 'variable' node is 1
  */
-export function dereference(context: Rule.RuleContext, node: ESTree.Node | undefined) {
+export function dereference(
+  context: Rule.RuleContext,
+  node: ESTree.Node | undefined,
+) {
   if (node?.type !== 'Identifier') {
     return node
   }

--- a/src/utils/ast.ts
+++ b/src/utils/ast.ts
@@ -9,10 +9,10 @@ export function getStringValue(node: ESTree.Node | undefined) {
   return node.type === 'Identifier'
     ? node.name
     : node.type === 'TemplateLiteral'
-      ? node.quasis[0].value.raw
-      : node.type === 'Literal' && typeof node.value === 'string'
-        ? node.value
-        : ''
+    ? node.quasis[0].value.raw
+    : node.type === 'Literal' && typeof node.value === 'string'
+    ? node.value
+    : ''
 }
 
 export function getRawValue(node: ESTree.Node) {
@@ -106,10 +106,10 @@ export function dig(node: ESTree.Node, identifier: string | RegExp): boolean {
   return node.type === 'MemberExpression'
     ? dig(node.property, identifier)
     : node.type === 'CallExpression'
-      ? dig(node.callee, identifier)
-      : node.type === 'Identifier'
-        ? isIdentifier(node, identifier)
-        : false
+    ? dig(node.callee, identifier)
+    : node.type === 'Identifier'
+    ? isIdentifier(node, identifier)
+    : false
 }
 
 export function isPageMethod(node: ESTree.CallExpression, name: string) {

--- a/src/utils/ast.ts
+++ b/src/utils/ast.ts
@@ -1,5 +1,5 @@
 import { Rule } from 'eslint'
-import ESTree from 'estree'
+import ESTree, { AssignmentExpression } from 'estree'
 import { isSupportedAccessor } from './parseFnCall'
 import { NodeWithParent, TypedNodeWithParent } from './types'
 
@@ -157,4 +157,86 @@ export function getNodeName(node: ESTree.Node): string | null {
   }
 
   return null
+}
+
+const isVariableDeclarator = (
+  node: ESTree.Node,
+): node is TypedNodeWithParent<'VariableDeclarator'> =>
+  node.type === 'VariableDeclarator'
+
+const isAssignmentExpression = (
+  node: ESTree.Node,
+): node is TypedNodeWithParent<'AssignmentExpression'> =>
+  node.type === 'AssignmentExpression'
+  
+/**
+ * Given a Node and an assignment expression, finds out if the assignment
+ * expression happens before the node identifier (based on their range
+ * properties) and if the assignment expression left side is of the same name as
+ * the name of the given node.
+ *
+ * @param node The node we are comparing the assignment expression to.
+ * @param assignment The assignment that will be verified to see if its left
+ *   operand is the same as the node.name and if it happens before it.
+ * @returns True if the assignment left hand operator belongs to the node and
+ *   occurs before it, false otherwise. If either the node or the assignment
+ *   expression doesn't contain a range array, this will also return false
+ *   because their relative positions cannot be calculated.
+ */
+function isNodeLastAssignment(
+  node: ESTree.Identifier,
+  assignment: AssignmentExpression,
+) {
+  if (node.range && assignment.range && node.range[0] < assignment.range[1]) {
+    return false
+  }
+
+  return (
+    assignment.left.type === 'Identifier' && assignment.left.name === node.name
+  )
+}
+
+/**
+ * If the node argument is a variable reference, finds the variable
+ * initializer or last variable assignment and returns the assigned value.
+ *
+ * If a variable is assigned after initialization we have to look for the last
+ * time it was assigned because it could have been changed multiple times. We
+ * then use its right hand assignment operator as the dereferenced node.
+ * 
+ * @example <caption>Dereference a `const` initialized node:</caption>
+ * // returns 1
+ * const variable = 1;
+ * console.log(variable) // dereferenced value of the 'variable' node is 1
+ *  
+ * @example <caption>Dereference a `let` re-assigned node:</caption>
+ * // returns 1
+ * let variable = 0;
+ * variable = 1;
+ * console.log(variable) // dereferenced value of the 'variable' node is 1
+ */
+export function dereference(context: Rule.RuleContext, node: ESTree.Node | undefined) {
+  if (node?.type !== 'Identifier') {
+    return node
+  }
+
+  const scope = context.sourceCode.getScope(node)
+  const parents = scope.references
+    .map((ref) => ref.identifier as Rule.Node)
+    .map((ident) => ident.parent)
+
+  // Look for any variable declarators in the scope references that match the
+  // dereferenced node variable name
+  const decl = parents
+    .filter(isVariableDeclarator)
+    .find((p) => p.id.type === 'Identifier' && p.id.name === node.name)
+
+  // Look for any variable assignments in the scope references and pick the last
+  // one that matches the dereferenced node variable name
+  const expr = parents
+    .filter(isAssignmentExpression)
+    .reverse()
+    .find((assignment) => isNodeLastAssignment(node, assignment))
+
+  return expr?.right ?? decl?.init
 }


### PR DESCRIPTION
ISSUE #293: 
The current prefer-to-have-count rule has a problem where any expect checks that take a variable argument will not check to make sure the value is not originating from a .count call. 

For example the following code would not be flagged as an error:

```ts
   const filesCount = await files.count();
   expect(filesCount).toBe(2);
```

The current code misses this case because we are not dereferencing the last assigned value of `filesCount` at the moment of verifying the expect argument. The rule should flag the error and return the following as a fix:

```ts
   const filesCount = files;
   await expect(filesCount).toHaveCount(2);
```

SOLUTION:

This PR updates the `prefer-to-have-count` code to re-use the `dereference` method previously used by the `prefer-web-first-assertion` rule. To make this method available to other files I moved it, along with all its related methods, to the `ast.ts` file which looked to me like the best place to centralize it (curious to know if there is a better place for these methods though).

I have added multiple new tests to check for other edge cases like variable re-assignment.