### PR TITLE
feat: add a rule to enforce closing the context 

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,6 +162,7 @@ CLI option\
 
 | Rule                                                                                                                                                | Description                                                        | ✅  | 🔧  | 💡  |
 | --------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------ | :-: | :-: | :-: |
+| [context-close](https://github.com/playwright-community/eslint-plugin-playwright/tree/main/docs/rules/context-close.md)                             | Enforce closing the context if has been created                        | ✅  |     |     |
 | [expect-expect](https://github.com/playwright-community/eslint-plugin-playwright/tree/main/docs/rules/expect-expect.md)                             | Enforce assertion to be made in a test body                        | ✅  |     |     |
 | [max-expects](https://github.com/playwright-community/eslint-plugin-playwright/tree/main/docs/rules/max-expects.md)                                 | Enforces a maximum number assertion calls in a test body           | ✅  |     |     |
 | [max-nested-describe](https://github.com/playwright-community/eslint-plugin-playwright/tree/main/docs/rules/max-nested-describe.md)                 | Enforces a maximum depth to nested describe calls                  | ✅  |     |     |

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,5 @@
 import globals from 'globals'
+import contextClose from './rules/context-close'
 import expectExpect from './rules/expect-expect'
 import maxExpects from './rules/max-expects'
 import maxNestedDescribe from './rules/max-nested-describe'
@@ -49,6 +50,7 @@ import validTitle from './rules/valid-title'
 const index = {
   configs: {},
   rules: {
+    'context-close': contextClose,
     'expect-expect': expectExpect,
     'max-expects': maxExpects,
     'max-nested-describe': maxNestedDescribe,
@@ -101,6 +103,7 @@ const index = {
 const sharedConfig = {
   rules: {
     'no-empty-pattern': 'off',
+    'playwright/context-close': 'error',
     'playwright/expect-expect': 'warn',
     'playwright/max-nested-describe': 'warn',
     'playwright/missing-playwright-await': 'error',

--- a/src/rules/context-close.test.ts
+++ b/src/rules/context-close.test.ts
@@ -1,0 +1,103 @@
+import rule from '../../src/rules/context-close'
+import { javascript, runRuleTester } from '../utils/rule-tester'
+
+runRuleTester('context-close', rule, {
+  invalid: [
+    {
+      code: javascript`
+            function createContext() {
+            
+            }
+    
+            function close() {
+            
+            }
+    
+    
+            (() => {
+                createContext();
+            })()
+            `,
+      errors: 1,
+    },
+    {
+      code: javascript`
+              const page = {
+                close: () => 'closed'
+              }
+              const browser = {
+                createContext: () => page
+              }
+      
+              
+              (() => {
+                  const newPage = browser.createContext();
+              })()
+              `,
+      errors: 1,
+    },
+  ],
+  valid: [
+    {
+      // different scopes invocation as expression
+      code: javascript`
+            function createContext() { }
+    
+            function close() {}
+    
+            createContext();
+            (() => {
+                
+                close();
+            })()
+            `,
+    },
+    {
+      // invocation in same scope as expression
+      code: javascript`
+              function createContext() { }
+      
+              function close() {}
+      
+              (() => {
+                  createContext();
+                  close();
+              })()
+              `,
+    },
+    {
+      // different scopes invocation as method
+      code: javascript`
+              const page = {
+                close: () => 'closed'
+              }
+              const browser = {
+                createContext: () => page
+              }
+      
+              const newPage = browser.createContext();
+              (() => {
+                  
+                  newPage.close();
+              })()
+              `,
+    },
+    {
+      // invocation in same scope as method
+      code: javascript`
+              const page = {
+                close: () => 'closed'
+              }
+              const browser = {
+                createContext: () => page
+              }
+      
+              
+              (() => {
+                  const newPage = browser.createContext();
+                  newPage.close();
+              })()
+              `,
+    },
+  ],
+})

--- a/src/rules/context-close.ts
+++ b/src/rules/context-close.ts
@@ -1,0 +1,86 @@
+import * as ESTree from 'estree'
+import { createRule } from '../utils/createRule'
+
+function isInvokedMethodCalled(
+  node: ESTree.CallExpression,
+  name: string,
+): boolean {
+  return (
+    node.callee.type === 'MemberExpression' &&
+    node.callee.object.type === 'Identifier' &&
+    node.callee.property.type === 'Identifier' &&
+    node.callee.property.name === name
+  )
+}
+
+function isInvokeExpressionCalled(
+  node: ESTree.ExpressionStatement,
+  name: string,
+): boolean {
+  return (
+    node.type === 'ExpressionStatement' &&
+    node.expression.type === 'CallExpression' &&
+    node.expression.callee.type === 'Identifier' &&
+    node.expression.callee.name === name
+  )
+}
+
+export default createRule({
+  create(context) {
+    const createContextStackAsMethod: Array<ESTree.CallExpression> = []
+    const createContextStackAsExpression: Array<ESTree.ExpressionStatement> = []
+    return {
+      CallExpression: (node) => {
+        if (isInvokedMethodCalled(node, 'createContext')) {
+          createContextStackAsMethod.push(node)
+        } else if (isInvokedMethodCalled(node, 'close')) {
+          if (createContextStackAsMethod.length > 0) {
+            createContextStackAsMethod.pop()
+          }
+        }
+      },
+      ExpressionStatement: (expressionStatementNode) => {
+        if (
+          isInvokeExpressionCalled(expressionStatementNode, 'createContext')
+        ) {
+          createContextStackAsExpression.push(expressionStatementNode)
+        } else if (isInvokeExpressionCalled(expressionStatementNode, 'close')) {
+          if (createContextStackAsExpression.length > 0) {
+            createContextStackAsExpression.pop()
+          }
+        }
+      },
+      'Program:exit'() {
+        if (createContextStackAsMethod.length > 0) {
+          for (const createContextNodeAsMethod of createContextStackAsMethod) {
+            context.report({
+              messageId: 'missingClose',
+              node: createContextNodeAsMethod,
+            })
+          }
+        }
+
+        if (createContextStackAsExpression.length > 0) {
+          for (const createContextNodeAsExpression of createContextStackAsExpression) {
+            context.report({
+              messageId: 'missingClose',
+              node: createContextNodeAsExpression,
+            })
+          }
+        }
+      },
+    }
+  },
+  meta: {
+    docs: {
+      description:
+        'Enforce closing a context once opened to prevent memory leaks',
+    },
+    messages: {
+      missingClose:
+        'A context has been created without a matching close function',
+    },
+    schema: [],
+    type: 'problem',
+  },
+})


### PR DESCRIPTION
Add a rule that enforce closing the context in case has been opened as specified in [documentation](https://playwright.dev/docs/api/class-browsercontext)