### PR TITLE
Add rule to suggest using built-in locators (`prefer-native-locators`)

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,8 +155,7 @@ messages will use the default message defined by the plugin.
 ## Rules
 
 ✅ Set in the `recommended` configuration\
-🔧 Automatically fixable by the
-[`--fix`](https://eslint.org/docs/latest/user-guide/command-line-interface#--fix)
+🔧 Automatically fixable by the [`--fix`](https://eslint.org/docs/latest/user-guide/command-line-interface#--fix)
 CLI option\
 💡 Manually fixable by
 [editor suggestions](https://eslint.org/docs/latest/developer-guide/working-with-rules#providing-suggestions)

--- a/README.md
+++ b/README.md
@@ -155,7 +155,8 @@ messages will use the default message defined by the plugin.
 ## Rules
 
 ✅ Set in the `recommended` configuration\
-🔧 Automatically fixable by the [`--fix`](https://eslint.org/docs/latest/user-guide/command-line-interface#--fix)
+🔧 Automatically fixable by the
+[`--fix`](https://eslint.org/docs/latest/user-guide/command-line-interface#--fix)
 CLI option\
 💡 Manually fixable by
 [editor suggestions](https://eslint.org/docs/latest/developer-guide/working-with-rules#providing-suggestions)
@@ -194,6 +195,7 @@ CLI option\
 | [prefer-hooks-in-order](https://github.com/playwright-community/eslint-plugin-playwright/tree/main/docs/rules/prefer-hooks-in-order.md)             | Prefer having hooks in a consistent order                          |     |     |     |
 | [prefer-hooks-on-top](https://github.com/playwright-community/eslint-plugin-playwright/tree/main/docs/rules/prefer-hooks-on-top.md)                 | Suggest having hooks before any test cases                         |     |     |     |
 | [prefer-lowercase-title](https://github.com/playwright-community/eslint-plugin-playwright/tree/main/docs/rules/prefer-lowercase-title.md)           | Enforce lowercase test names                                       |     | 🔧  |     |
+| [prefer-native-locators](https://github.com/playwright-community/eslint-plugin-playwright/tree/main/docs/rules/prefer-native-locators.md)           | Suggest built-in locators over `page.locator()`                    |     | 🔧  |     |
 | [prefer-strict-equal](https://github.com/playwright-community/eslint-plugin-playwright/tree/main/docs/rules/prefer-strict-equal.md)                 | Suggest using `toStrictEqual()`                                    |     |     | 💡  |
 | [prefer-to-be](https://github.com/playwright-community/eslint-plugin-playwright/tree/main/docs/rules/prefer-to-be.md)                               | Suggest using `toBe()`                                             |     | 🔧  |     |
 | [prefer-to-contain](https://github.com/playwright-community/eslint-plugin-playwright/tree/main/docs/rules/prefer-to-contain.md)                     | Suggest using `toContain()`                                        |     | 🔧  |     |

--- a/docs/rules/prefer-native-locators.md
+++ b/docs/rules/prefer-native-locators.md
@@ -1,0 +1,34 @@
+# Suggest using native Playwright locators (`prefer-native-locators`)
+
+Playwright has built-in locators for common query selectors such as finding
+elements by placeholder text, ARIA role, accessible name, and more. This rule
+suggests using these native locators instead of using `page.locator()` with an
+equivalent selector.
+
+In some cases this can be more robust too, such as finding elements by ARIA role
+or accessible name, because some elements have implicit roles, and there are
+multiple ways to specify accessible names.
+
+## Rule details
+
+Examples of **incorrect** code for this rule:
+
+```javascript
+page.locator('[aria-label="View more"]')
+page.locator('[role="button"]')
+page.locator('[placeholder="Enter some text..."]')
+page.locator('[alt="Playwright logo"]')
+page.locator('[title="Additional context"]')
+page.locator('[data-testid="password-input"]')
+```
+
+Examples of **correct** code for this rule:
+
+```javascript
+page.getByLabel('View more')
+page.getByRole('Button')
+page.getByPlaceholder('Enter some text...')
+page.getByAltText('Playwright logo')
+page.getByTestId('password-input')
+page.getByTitle('Additional context')
+```

--- a/docs/rules/prefer-native-locators.md
+++ b/docs/rules/prefer-native-locators.md
@@ -32,3 +32,39 @@ page.getByAltText('Playwright logo')
 page.getByTestId('password-input')
 page.getByTitle('Additional context')
 ```
+
+## Options
+
+```json
+{
+  "playwright/prefer-native-locators": [
+    "error",
+    {
+      "testIdAttribute": "data-testid"
+    }
+  ]
+}
+```
+
+### `testIdAttribute`
+
+Default: `data-testid`
+
+This string option specifies the test ID attribute to look for and replace with
+`page.getByTestId()` calls. If you are using
+[`page.setTestIdAttribute()`](https://playwright.dev/docs/api/class-selectors#selectors-set-test-id-attribute),
+this should be set to the same value as what you pass in to that method.
+
+Examples of **incorrect** code when using
+`{ "testIdAttribute": "data-custom-testid" }` option:
+
+```js
+page.locator('[data-custom-testid="password-input"]')
+```
+
+Examples of **correct** code when using
+`{ "testIdAttribute": "data-custom-testid" }` option:
+
+```js
+page.getByTestId('password-input')
+```

--- a/src/index.ts
+++ b/src/index.ts
@@ -31,6 +31,7 @@ import preferEqualityMatcher from './rules/prefer-equality-matcher'
 import preferHooksInOrder from './rules/prefer-hooks-in-order'
 import preferHooksOnTop from './rules/prefer-hooks-on-top'
 import preferLowercaseTitle from './rules/prefer-lowercase-title'
+import preferNativeLocators from './rules/prefer-native-locators'
 import preferStrictEqual from './rules/prefer-strict-equal'
 import preferToBe from './rules/prefer-to-be'
 import preferToContain from './rules/prefer-to-contain'
@@ -81,6 +82,7 @@ const index = {
     'prefer-hooks-in-order': preferHooksInOrder,
     'prefer-hooks-on-top': preferHooksOnTop,
     'prefer-lowercase-title': preferLowercaseTitle,
+    'prefer-native-locators': preferNativeLocators,
     'prefer-strict-equal': preferStrictEqual,
     'prefer-to-be': preferToBe,
     'prefer-to-contain': preferToContain,

--- a/src/rules/prefer-native-locators.test.ts
+++ b/src/rules/prefer-native-locators.test.ts
@@ -98,16 +98,58 @@ runRuleTester('prefer-native-locators', rule, {
       errors: [{ column: 7, line: 1, messageId: 'unexpectedPlaceholderQuery' }],
       output: 'await page.getByPlaceholder("New password").click()',
     },
+    // Works as part of a declaration or other usage
+    {
+      code: `const dialog = page.locator('[role="dialog"]')`,
+      errors: [{ column: 16, line: 1, messageId: 'unexpectedRoleQuery' }],
+      output: 'const dialog = page.getByRole("dialog")',
+    },
+    {
+      code: `this.closeModalLocator = this.page.locator('[data-test=close-modal]');`,
+      errors: [{ column: 26, line: 1, messageId: 'unexpectedTestIdQuery' }],
+      options: [{ testIdAttribute: 'data-test' }],
+      output: 'this.closeModalLocator = this.page.getByTestId("close-modal");',
+    },
+    {
+      code: `export class TestClass {
+        container = () => this.page.locator('[data-testid="container"]');
+      }`,
+      errors: [{ column: 27, line: 2, messageId: 'unexpectedTestIdQuery' }],
+      output: `export class TestClass {
+        container = () => this.page.getByTestId("container");
+      }`,
+    },
+    {
+      code: `export class TestClass {
+        get alert() {
+          return this.page.locator("[role='alert']");
+        }
+      }`,
+      errors: [{ column: 18, line: 3, messageId: 'unexpectedRoleQuery' }],
+      output: `export class TestClass {
+        get alert() {
+          return this.page.getByRole("alert");
+        }
+      }`,
+    },
   ],
   valid: [
     { code: 'page.getByLabel("View more")' },
     { code: 'page.getByRole("button")' },
+    { code: 'page.getByRole("button", {name: "Open"})' },
     { code: 'page.getByPlaceholder("Enter some text...")' },
     { code: 'page.getByAltText("Playwright logo")' },
     { code: 'page.getByTestId("password-input")' },
     { code: 'page.getByTitle("Additional context")' },
+    { code: 'this.page.getByLabel("View more")' },
+    { code: 'this.page.getByRole("button")' },
+    { code: 'this.page.getByPlaceholder("Enter some text...")' },
+    { code: 'this.page.getByAltText("Playwright logo")' },
+    { code: 'this.page.getByTestId("password-input")' },
+    { code: 'this.page.getByTitle("Additional context")' },
     { code: 'page.locator(".class")' },
     { code: 'page.locator("#id")' },
+    { code: 'this.page.locator("#id")' },
     // Does not match on more complex queries
     {
       code: `page.locator('[complex-query] > [aria-label="View more"]')`,
@@ -127,8 +169,26 @@ runRuleTester('prefer-native-locators', rule, {
     {
       code: `page.locator('[complex-query] > [title="Additional context"]')`,
     },
+    {
+      code: `this.page.locator('[complex-query] > [title="Additional context"]')`,
+    },
     // Works for empty string and no arguments
     { code: `page.locator('')` },
     { code: `page.locator()` },
+    // Works for classes and declarations
+    { code: `const dialog = page.getByRole("dialog")` },
+    {
+      code: `export class TestClass {
+        get alert() {
+          return this.page.getByRole("alert");
+        }
+      }`,
+    },
+    {
+      code: `export class TestClass {
+        container = () => this.page.getByTestId("container");
+      }`,
+    },
+    { code: `this.closeModalLocator = this.page.getByTestId("close-modal");` },
   ],
 })

--- a/src/rules/prefer-native-locators.test.ts
+++ b/src/rules/prefer-native-locators.test.ts
@@ -62,12 +62,6 @@ runRuleTester('prefer-native-locators', rule, {
       errors: [{ column: 7, line: 1, messageId: 'unexpectedPlaceholderQuery' }],
       output: 'await page.getByPlaceholder("New password").click()',
     },
-    // Works when it is not page.locator
-    {
-      code: `this.locator('[aria-label="View more"]')`,
-      errors: [{ column: 1, line: 1, messageId: 'unexpectedLabelQuery' }],
-      output: 'this.getByLabel("View more")',
-    },
   ],
   valid: [
     { code: 'page.getByLabel("View more")' },

--- a/src/rules/prefer-native-locators.test.ts
+++ b/src/rules/prefer-native-locators.test.ts
@@ -13,15 +13,24 @@ runRuleTester('prefer-native-locators', rule, {
       errors: [{ column: 1, line: 1, messageId: 'unexpectedRoleQuery' }],
       output: 'page.getByRole("button")',
     },
+    {
+      code: `page.locator('[placeholder="Enter some text..."]')`,
+      errors: [{ column: 1, line: 1, messageId: 'unexpectedPlaceholderQuery' }],
+      output: 'page.getByPlaceholder("Enter some text...")',
+    },
   ],
   valid: [
     { code: 'page.getByLabel("View more")' },
     { code: 'page.getByRole("Button")' },
+    { code: 'page.getByPlaceholder("Enter some text...")' },
     {
       code: `page.locator('[complex-query] > [aria-label="View more"]')`,
     },
     {
       code: `page.locator('[complex-query] > [role="button"]')`,
+    },
+    {
+      code: `page.locator('[complex-query] > [placeholder="Enter some text..."]')`,
     },
   ],
 })

--- a/src/rules/prefer-native-locators.test.ts
+++ b/src/rules/prefer-native-locators.test.ts
@@ -1,0 +1,18 @@
+import { runRuleTester } from '../utils/rule-tester'
+import rule from './prefer-native-locators'
+
+runRuleTester('prefer-native-locators', rule, {
+  invalid: [
+    {
+      code: `page.locator('[aria-label="View more"]')`,
+      errors: [{ column: 1, line: 1, messageId: 'unexpectedLabelQuery' }],
+      output: 'page.getByLabel("View more")',
+    },
+  ],
+  valid: [
+    { code: 'page.getByLabel("View more")' },
+    {
+      code: `page.locator('[something-more-complex][aria-label="View more"]')`,
+    },
+  ],
+})

--- a/src/rules/prefer-native-locators.test.ts
+++ b/src/rules/prefer-native-locators.test.ts
@@ -9,7 +9,17 @@ runRuleTester('prefer-native-locators', rule, {
       output: 'page.getByLabel("View more")',
     },
     {
+      code: `page.locator('[aria-label=Edit]')`,
+      errors: [{ column: 1, line: 1, messageId: 'unexpectedLabelQuery' }],
+      output: 'page.getByLabel("Edit")',
+    },
+    {
       code: `page.locator('[role="button"]')`,
+      errors: [{ column: 1, line: 1, messageId: 'unexpectedRoleQuery' }],
+      output: 'page.getByRole("button")',
+    },
+    {
+      code: `page.locator('[role=button]')`,
       errors: [{ column: 1, line: 1, messageId: 'unexpectedRoleQuery' }],
       output: 'page.getByRole("button")',
     },
@@ -19,9 +29,19 @@ runRuleTester('prefer-native-locators', rule, {
       output: 'page.getByPlaceholder("Enter some text...")',
     },
     {
+      code: `page.locator('[placeholder=Name]')`,
+      errors: [{ column: 1, line: 1, messageId: 'unexpectedPlaceholderQuery' }],
+      output: 'page.getByPlaceholder("Name")',
+    },
+    {
       code: `page.locator('[alt="Playwright logo"]')`,
       errors: [{ column: 1, line: 1, messageId: 'unexpectedAltTextQuery' }],
       output: 'page.getByAltText("Playwright logo")',
+    },
+    {
+      code: `page.locator('[alt=Logo]')`,
+      errors: [{ column: 1, line: 1, messageId: 'unexpectedAltTextQuery' }],
+      output: 'page.getByAltText("Logo")',
     },
     {
       code: `page.locator('[title="Additional context"]')`,
@@ -29,15 +49,31 @@ runRuleTester('prefer-native-locators', rule, {
       output: 'page.getByTitle("Additional context")',
     },
     {
+      code: `page.locator('[title=Context]')`,
+      errors: [{ column: 1, line: 1, messageId: 'unexpectedTitleQuery' }],
+      output: 'page.getByTitle("Context")',
+    },
+    {
       code: `page.locator('[data-testid="password-input"]')`,
       errors: [{ column: 1, line: 1, messageId: 'unexpectedTestIdQuery' }],
       output: 'page.getByTestId("password-input")',
+    },
+    {
+      code: `page.locator('[data-testid=input]')`,
+      errors: [{ column: 1, line: 1, messageId: 'unexpectedTestIdQuery' }],
+      output: 'page.getByTestId("input")',
     },
     {
       code: `page.locator('[data-custom-testid="password-input"]')`,
       errors: [{ column: 1, line: 1, messageId: 'unexpectedTestIdQuery' }],
       options: [{ testIdAttribute: 'data-custom-testid' }],
       output: 'page.getByTestId("password-input")',
+    },
+    {
+      code: `page.locator('[data-custom-testid=input]')`,
+      errors: [{ column: 1, line: 1, messageId: 'unexpectedTestIdQuery' }],
+      options: [{ testIdAttribute: 'data-custom-testid' }],
+      output: 'page.getByTestId("input")',
     },
     // Works when locators are chained
     {

--- a/src/rules/prefer-native-locators.test.ts
+++ b/src/rules/prefer-native-locators.test.ts
@@ -23,12 +23,18 @@ runRuleTester('prefer-native-locators', rule, {
       errors: [{ column: 1, line: 1, messageId: 'unexpectedAltTextQuery' }],
       output: 'page.getByAltText("Playwright logo")',
     },
+    {
+      code: `page.locator('[data-testid="password-input"]')`,
+      errors: [{ column: 1, line: 1, messageId: 'unexpectedTestIdQuery' }],
+      output: 'page.getByTestId("password-input")',
+    },
   ],
   valid: [
     { code: 'page.getByLabel("View more")' },
     { code: 'page.getByRole("Button")' },
     { code: 'page.getByPlaceholder("Enter some text...")' },
     { code: 'page.getByAltText("Playwright logo")' },
+    { code: 'page.getByTestId("password-input")' },
     {
       code: `page.locator('[complex-query] > [aria-label="View more"]')`,
     },
@@ -40,6 +46,9 @@ runRuleTester('prefer-native-locators', rule, {
     },
     {
       code: `page.locator('[complex-query] > [alt="Playwright logo"]')`,
+    },
+    {
+      code: `page.locator('[complex-query] > [data-testid="password-input"]')`,
     },
   ],
 })

--- a/src/rules/prefer-native-locators.test.ts
+++ b/src/rules/prefer-native-locators.test.ts
@@ -33,6 +33,12 @@ runRuleTester('prefer-native-locators', rule, {
       errors: [{ column: 1, line: 1, messageId: 'unexpectedTestIdQuery' }],
       output: 'page.getByTestId("password-input")',
     },
+    {
+      code: `page.locator('[data-custom-testid="password-input"]')`,
+      errors: [{ column: 1, line: 1, messageId: 'unexpectedTestIdQuery' }],
+      options: [{ testIdAttribute: 'data-custom-testid' }],
+      output: 'page.getByTestId("password-input")',
+    },
   ],
   valid: [
     { code: 'page.getByLabel("View more")' },

--- a/src/rules/prefer-native-locators.test.ts
+++ b/src/rules/prefer-native-locators.test.ts
@@ -18,11 +18,17 @@ runRuleTester('prefer-native-locators', rule, {
       errors: [{ column: 1, line: 1, messageId: 'unexpectedPlaceholderQuery' }],
       output: 'page.getByPlaceholder("Enter some text...")',
     },
+    {
+      code: `page.locator('[alt="Playwright logo"]')`,
+      errors: [{ column: 1, line: 1, messageId: 'unexpectedAltTextQuery' }],
+      output: 'page.getByAltText("Playwright logo")',
+    },
   ],
   valid: [
     { code: 'page.getByLabel("View more")' },
     { code: 'page.getByRole("Button")' },
     { code: 'page.getByPlaceholder("Enter some text...")' },
+    { code: 'page.getByAltText("Playwright logo")' },
     {
       code: `page.locator('[complex-query] > [aria-label="View more"]')`,
     },
@@ -31,6 +37,9 @@ runRuleTester('prefer-native-locators', rule, {
     },
     {
       code: `page.locator('[complex-query] > [placeholder="Enter some text..."]')`,
+    },
+    {
+      code: `page.locator('[complex-query] > [alt="Playwright logo"]')`,
     },
   ],
 })

--- a/src/rules/prefer-native-locators.test.ts
+++ b/src/rules/prefer-native-locators.test.ts
@@ -8,11 +8,20 @@ runRuleTester('prefer-native-locators', rule, {
       errors: [{ column: 1, line: 1, messageId: 'unexpectedLabelQuery' }],
       output: 'page.getByLabel("View more")',
     },
+    {
+      code: `page.locator('[role="button"]')`,
+      errors: [{ column: 1, line: 1, messageId: 'unexpectedRoleQuery' }],
+      output: 'page.getByRole("button")',
+    },
   ],
   valid: [
     { code: 'page.getByLabel("View more")' },
+    { code: 'page.getByRole("Button")' },
     {
-      code: `page.locator('[something-more-complex][aria-label="View more"]')`,
+      code: `page.locator('[complex-query] > [aria-label="View more"]')`,
+    },
+    {
+      code: `page.locator('[complex-query] > [role="button"]')`,
     },
   ],
 })

--- a/src/rules/prefer-native-locators.test.ts
+++ b/src/rules/prefer-native-locators.test.ts
@@ -71,7 +71,7 @@ runRuleTester('prefer-native-locators', rule, {
   ],
   valid: [
     { code: 'page.getByLabel("View more")' },
-    { code: 'page.getByRole("Button")' },
+    { code: 'page.getByRole("button")' },
     { code: 'page.getByPlaceholder("Enter some text...")' },
     { code: 'page.getByAltText("Playwright logo")' },
     { code: 'page.getByTestId("password-input")' },

--- a/src/rules/prefer-native-locators.test.ts
+++ b/src/rules/prefer-native-locators.test.ts
@@ -70,6 +70,8 @@ runRuleTester('prefer-native-locators', rule, {
     { code: 'page.getByAltText("Playwright logo")' },
     { code: 'page.getByTestId("password-input")' },
     { code: 'page.getByTitle("Additional context")' },
+    { code: 'page.locator(".class")' },
+    { code: 'page.locator("#id")' },
     // Does not match on more complex queries
     {
       code: `page.locator('[complex-query] > [aria-label="View more"]')`,

--- a/src/rules/prefer-native-locators.test.ts
+++ b/src/rules/prefer-native-locators.test.ts
@@ -24,6 +24,11 @@ runRuleTester('prefer-native-locators', rule, {
       output: 'page.getByAltText("Playwright logo")',
     },
     {
+      code: `page.locator('[title="Additional context"]')`,
+      errors: [{ column: 1, line: 1, messageId: 'unexpectedTitleQuery' }],
+      output: 'page.getByTitle("Additional context")',
+    },
+    {
       code: `page.locator('[data-testid="password-input"]')`,
       errors: [{ column: 1, line: 1, messageId: 'unexpectedTestIdQuery' }],
       output: 'page.getByTestId("password-input")',
@@ -35,6 +40,7 @@ runRuleTester('prefer-native-locators', rule, {
     { code: 'page.getByPlaceholder("Enter some text...")' },
     { code: 'page.getByAltText("Playwright logo")' },
     { code: 'page.getByTestId("password-input")' },
+    { code: 'page.getByTitle("Additional context")' },
     {
       code: `page.locator('[complex-query] > [aria-label="View more"]')`,
     },
@@ -49,6 +55,9 @@ runRuleTester('prefer-native-locators', rule, {
     },
     {
       code: `page.locator('[complex-query] > [data-testid="password-input"]')`,
+    },
+    {
+      code: `page.locator('[complex-query] > [title="Additional context"]')`,
     },
   ],
 })

--- a/src/rules/prefer-native-locators.test.ts
+++ b/src/rules/prefer-native-locators.test.ts
@@ -70,6 +70,7 @@ runRuleTester('prefer-native-locators', rule, {
     { code: 'page.getByAltText("Playwright logo")' },
     { code: 'page.getByTestId("password-input")' },
     { code: 'page.getByTitle("Additional context")' },
+    // Does not match on more complex queries
     {
       code: `page.locator('[complex-query] > [aria-label="View more"]')`,
     },
@@ -88,5 +89,8 @@ runRuleTester('prefer-native-locators', rule, {
     {
       code: `page.locator('[complex-query] > [title="Additional context"]')`,
     },
+    // Works for empty string and no arguments
+    { code: `page.locator('')` },
+    { code: `page.locator()` },
   ],
 })

--- a/src/rules/prefer-native-locators.test.ts
+++ b/src/rules/prefer-native-locators.test.ts
@@ -39,6 +39,35 @@ runRuleTester('prefer-native-locators', rule, {
       options: [{ testIdAttribute: 'data-custom-testid' }],
       output: 'page.getByTestId("password-input")',
     },
+    // Works when locators are chained
+    {
+      code: `this.page.locator('[role="heading"]').first()`,
+      errors: [{ column: 1, line: 1, messageId: 'unexpectedRoleQuery' }],
+      output: 'this.page.getByRole("heading").first()',
+    },
+    // Works when used inside an assertion
+    {
+      code: `await expect(page.locator('[role="alert"]')).toBeVisible()`,
+      errors: [{ column: 14, line: 1, messageId: 'unexpectedRoleQuery' }],
+      output: 'await expect(page.getByRole("alert")).toBeVisible()',
+    },
+    {
+      code: `await expect(page.locator('[data-testid="top"]')).toContainText(firstRule)`,
+      errors: [{ column: 14, line: 1, messageId: 'unexpectedTestIdQuery' }],
+      output: 'await expect(page.getByTestId("top")).toContainText(firstRule)',
+    },
+    // Works when used as part of an action
+    {
+      code: `await page.locator('[placeholder="New password"]').click()`,
+      errors: [{ column: 7, line: 1, messageId: 'unexpectedPlaceholderQuery' }],
+      output: 'await page.getByPlaceholder("New password").click()',
+    },
+    // Works when it is not page.locator
+    {
+      code: `this.locator('[aria-label="View more"]')`,
+      errors: [{ column: 1, line: 1, messageId: 'unexpectedLabelQuery' }],
+      output: 'this.getByLabel("View more")',
+    },
   ],
   valid: [
     { code: 'page.getByLabel("View more")' },

--- a/src/rules/prefer-native-locators.ts
+++ b/src/rules/prefer-native-locators.ts
@@ -24,10 +24,8 @@ export default createRule({
         if (labelMatch) {
           context.report({
             fix(fixer) {
-              return fixer.replaceTextRange(
-                rangeToReplace,
-                `getByLabel("${labelMatch[1]}")`,
-              )
+              const newText = `getByLabel("${labelMatch[1]}")`
+              return fixer.replaceTextRange(rangeToReplace, newText)
             },
             messageId: 'unexpectedLabelQuery',
             node,
@@ -39,10 +37,8 @@ export default createRule({
         if (roleMatch) {
           context.report({
             fix(fixer) {
-              return fixer.replaceTextRange(
-                rangeToReplace,
-                `getByRole("${roleMatch[1]}")`,
-              )
+              const newText = `getByRole("${roleMatch[1]}")`
+              return fixer.replaceTextRange(rangeToReplace, newText)
             },
             messageId: 'unexpectedRoleQuery',
             node,
@@ -54,10 +50,8 @@ export default createRule({
         if (placeholderMatch) {
           context.report({
             fix(fixer) {
-              return fixer.replaceTextRange(
-                rangeToReplace,
-                `getByPlaceholder("${placeholderMatch[1]}")`,
-              )
+              const newText = `getByPlaceholder("${placeholderMatch[1]}")`
+              return fixer.replaceTextRange(rangeToReplace, newText)
             },
             messageId: 'unexpectedPlaceholderQuery',
             node,
@@ -69,10 +63,8 @@ export default createRule({
         if (altTextMatch) {
           context.report({
             fix(fixer) {
-              return fixer.replaceTextRange(
-                rangeToReplace,
-                `getByAltText("${altTextMatch[1]}")`,
-              )
+              const newText = `getByAltText("${altTextMatch[1]}")`
+              return fixer.replaceTextRange(rangeToReplace, newText)
             },
             messageId: 'unexpectedAltTextQuery',
             node,
@@ -84,10 +76,8 @@ export default createRule({
         if (titleMatch) {
           context.report({
             fix(fixer) {
-              return fixer.replaceTextRange(
-                rangeToReplace,
-                `getByTitle("${titleMatch[1]}")`,
-              )
+              const newText = `getByTitle("${titleMatch[1]}")`
+              return fixer.replaceTextRange(rangeToReplace, newText)
             },
             messageId: 'unexpectedTitleQuery',
             node,
@@ -103,10 +93,8 @@ export default createRule({
         if (testIdMatch) {
           context.report({
             fix(fixer) {
-              return fixer.replaceTextRange(
-                rangeToReplace,
-                `getByTestId("${testIdMatch[1]}")`,
-              )
+              const newText = `getByTestId("${testIdMatch[1]}")`
+              return fixer.replaceTextRange(rangeToReplace, newText)
             },
             messageId: 'unexpectedTestIdQuery',
             node,

--- a/src/rules/prefer-native-locators.ts
+++ b/src/rules/prefer-native-locators.ts
@@ -11,19 +11,22 @@ export default createRule({
         const isLocator = isPageMethod(node, 'locator') || method === 'locator'
         if (!isLocator) return
 
+        // If it's something like `page.locator`, just replace the `.locator` part
+        const start =
+          node.callee.type === 'MemberExpression'
+            ? node.callee.property.range![0]
+            : node.range![0]
+        const end = node.range![1]
+        const rangeToReplace: [number, number] = [start, end]
+
         const ariaLabelPattern = /^\[aria-label=['"](.+?)['"]\]$/
-        if (query.match(ariaLabelPattern)) {
+        const labelMatch = query.match(ariaLabelPattern)
+        if (labelMatch) {
           context.report({
             fix(fixer) {
-              const [, label] = query.match(ariaLabelPattern) ?? []
-              const start =
-                node.callee.type === 'MemberExpression'
-                  ? node.callee.property.range![0]
-                  : node.range![0]
-              const end = node.range![1]
               return fixer.replaceTextRange(
-                [start, end],
-                `getByLabel("${label}")`,
+                rangeToReplace,
+                `getByLabel("${labelMatch[1]}")`,
               )
             },
             messageId: 'unexpectedLabelQuery',
@@ -32,18 +35,13 @@ export default createRule({
         }
 
         const rolePattern = /^\[role=['"](.+?)['"]\]$/
-        if (query.match(rolePattern)) {
+        const roleMatch = query.match(rolePattern)
+        if (roleMatch) {
           context.report({
             fix(fixer) {
-              const [, role] = query.match(rolePattern) ?? []
-              const start =
-                node.callee.type === 'MemberExpression'
-                  ? node.callee.property.range![0]
-                  : node.range![0]
-              const end = node.range![1]
               return fixer.replaceTextRange(
-                [start, end],
-                `getByRole("${role}")`,
+                rangeToReplace,
+                `getByRole("${roleMatch[1]}")`,
               )
             },
             messageId: 'unexpectedRoleQuery',
@@ -52,18 +50,13 @@ export default createRule({
         }
 
         const placeholderPattern = /^\[placeholder=['"](.+?)['"]\]$/
-        if (query.match(placeholderPattern)) {
+        const placeholderMatch = query.match(placeholderPattern)
+        if (placeholderMatch) {
           context.report({
             fix(fixer) {
-              const [, placeholder] = query.match(placeholderPattern) ?? []
-              const start =
-                node.callee.type === 'MemberExpression'
-                  ? node.callee.property.range![0]
-                  : node.range![0]
-              const end = node.range![1]
               return fixer.replaceTextRange(
-                [start, end],
-                `getByPlaceholder("${placeholder}")`,
+                rangeToReplace,
+                `getByPlaceholder("${placeholderMatch[1]}")`,
               )
             },
             messageId: 'unexpectedPlaceholderQuery',
@@ -72,18 +65,13 @@ export default createRule({
         }
 
         const altTextPattern = /^\[alt=['"](.+?)['"]\]$/
-        if (query.match(altTextPattern)) {
+        const altTextMatch = query.match(altTextPattern)
+        if (altTextMatch) {
           context.report({
             fix(fixer) {
-              const [, alt] = query.match(altTextPattern) ?? []
-              const start =
-                node.callee.type === 'MemberExpression'
-                  ? node.callee.property.range![0]
-                  : node.range![0]
-              const end = node.range![1]
               return fixer.replaceTextRange(
-                [start, end],
-                `getByAltText("${alt}")`,
+                rangeToReplace,
+                `getByAltText("${altTextMatch[1]}")`,
               )
             },
             messageId: 'unexpectedAltTextQuery',
@@ -92,18 +80,13 @@ export default createRule({
         }
 
         const titlePattern = /^\[title=['"](.+?)['"]\]$/
-        if (query.match(titlePattern)) {
+        const titleMatch = query.match(titlePattern)
+        if (titleMatch) {
           context.report({
             fix(fixer) {
-              const [, title] = query.match(titlePattern) ?? []
-              const start =
-                node.callee.type === 'MemberExpression'
-                  ? node.callee.property.range![0]
-                  : node.range![0]
-              const end = node.range![1]
               return fixer.replaceTextRange(
-                [start, end],
-                `getByTitle("${title}")`,
+                rangeToReplace,
+                `getByTitle("${titleMatch[1]}")`,
               )
             },
             messageId: 'unexpectedTitleQuery',
@@ -116,18 +99,13 @@ export default createRule({
         const testIdPattern = new RegExp(
           `^\\[${testIdAttributeName}=['"](.+?)['"]\\]`,
         )
-        if (query.match(testIdPattern)) {
+        const testIdMatch = query.match(testIdPattern)
+        if (testIdMatch) {
           context.report({
             fix(fixer) {
-              const [, testId] = query.match(testIdPattern) ?? []
-              const start =
-                node.callee.type === 'MemberExpression'
-                  ? node.callee.property.range![0]
-                  : node.range![0]
-              const end = node.range![1]
               return fixer.replaceTextRange(
-                [start, end],
-                `getByTestId("${testId}")`,
+                rangeToReplace,
+                `getByTestId("${testIdMatch[1]}")`,
               )
             },
             messageId: 'unexpectedTestIdQuery',

--- a/src/rules/prefer-native-locators.ts
+++ b/src/rules/prefer-native-locators.ts
@@ -90,6 +90,30 @@ export default createRule({
             node,
           })
         }
+
+        // TODO: Add support for custom test ID attribute
+        const testIdAttributeName = 'data-testid'
+        const testIdPattern = new RegExp(
+          `^\\[${testIdAttributeName}=['"](.+?)['"]\\]`,
+        )
+        if (query.match(testIdPattern)) {
+          context.report({
+            fix(fixer) {
+              const [, testId] = query.match(testIdPattern) ?? []
+              const start =
+                node.callee.type === 'MemberExpression'
+                  ? node.callee.property.range![0]
+                  : node.range![0]
+              const end = node.range![1]
+              return fixer.replaceTextRange(
+                [start, end],
+                `getByTestId("${testId}")`,
+              )
+            },
+            messageId: 'unexpectedTestIdQuery',
+            node,
+          })
+        }
       },
     }
   },

--- a/src/rules/prefer-native-locators.ts
+++ b/src/rules/prefer-native-locators.ts
@@ -1,0 +1,55 @@
+import { getStringValue, isPageMethod } from '../utils/ast'
+import { createRule } from '../utils/createRule'
+
+export default createRule({
+  create(context) {
+    return {
+      CallExpression(node) {
+        if (node.callee.type !== 'MemberExpression') return
+        const method = getStringValue(node.callee.property)
+        const query = getStringValue(node.arguments[0])
+        const isLocator = isPageMethod(node, 'locator') || method === 'locator'
+        if (!isLocator) return
+
+        const ariaLabelPattern = /^\[aria-label=['"](.+?)['"]\]$/
+        if (query.match(ariaLabelPattern)) {
+          context.report({
+            fix(fixer) {
+              const [, label] = query.match(ariaLabelPattern) ?? []
+              // Replace .locator(...) with .getByLabel(...)
+              const start =
+                node.callee.type === 'MemberExpression'
+                  ? node.callee.property.range![0]
+                  : node.range![0]
+              const end = node.range![1]
+              return fixer.replaceTextRange(
+                [start, end],
+                `getByLabel("${label}")`,
+              )
+            },
+            messageId: 'unexpectedLabelQuery',
+            node,
+          })
+        }
+      },
+    }
+  },
+  meta: {
+    docs: {
+      category: 'Best Practices',
+      description: 'Prefer native locator functions',
+      recommended: false,
+      url: 'https://github.com/playwright-community/eslint-plugin-playwright/tree/main/docs/rules/prefer-native-locators.md',
+    },
+    fixable: 'code',
+    messages: {
+      unexpectedAltTextQuery: 'Use .getByAltText() instead',
+      unexpectedLabelQuery: 'Use .getByLabel() instead',
+      unexpectedPlaceholderQuery: 'Use .getByPlaceholder() instead',
+      unexpectedRoleQuery: 'Use .getByRole() instead',
+      unexpectedTestIdQuery: 'Use .getByTestId() instead',
+    },
+    schema: [],
+    type: 'suggestion',
+  },
+})

--- a/src/rules/prefer-native-locators.ts
+++ b/src/rules/prefer-native-locators.ts
@@ -8,6 +8,49 @@ type Pattern = {
   replacement: string
 }
 
+const compilePatterns = ({
+  testIdAttribute,
+}: {
+  testIdAttribute: string
+}): Pattern[] => {
+  const patterns = [
+    {
+      attribute: 'aria-label',
+      messageId: 'unexpectedLabelQuery',
+      replacement: 'getByLabel',
+    },
+    {
+      attribute: 'role',
+      messageId: 'unexpectedRoleQuery',
+      replacement: 'getByRole',
+    },
+    {
+      attribute: 'placeholder',
+      messageId: 'unexpectedPlaceholderQuery',
+      replacement: 'getByPlaceholder',
+    },
+    {
+      attribute: 'alt',
+      messageId: 'unexpectedAltTextQuery',
+      replacement: 'getByAltText',
+    },
+    {
+      attribute: 'title',
+      messageId: 'unexpectedTitleQuery',
+      replacement: 'getByTitle',
+    },
+    {
+      attribute: testIdAttribute,
+      messageId: 'unexpectedTestIdQuery',
+      replacement: 'getByTestId',
+    },
+  ]
+  return patterns.map(({ attribute, ...pattern }) => ({
+    ...pattern,
+    pattern: new RegExp(`^\\[${attribute}=['"]?(.+?)['"]?\\]$`),
+  }))
+}
+
 export default createRule({
   create(context) {
     const { testIdAttribute } = {
@@ -15,38 +58,7 @@ export default createRule({
       ...((context.options?.[0] as Record<string, unknown>) ?? {}),
     }
 
-    const patterns: Array<Pattern> = [
-      {
-        messageId: 'unexpectedLabelQuery',
-        pattern: /^\[aria-label=['"]?(.+?)['"]?\]$/,
-        replacement: 'getByLabel',
-      },
-      {
-        messageId: 'unexpectedRoleQuery',
-        pattern: /^\[role=['"]?(.+?)['"]?\]$/,
-        replacement: 'getByRole',
-      },
-      {
-        messageId: 'unexpectedPlaceholderQuery',
-        pattern: /^\[placeholder=['"]?(.+?)['"]?\]$/,
-        replacement: 'getByPlaceholder',
-      },
-      {
-        messageId: 'unexpectedAltTextQuery',
-        pattern: /^\[alt=['"]?(.+?)['"]?\]$/,
-        replacement: 'getByAltText',
-      },
-      {
-        messageId: 'unexpectedTitleQuery',
-        pattern: /^\[title=['"]?(.+?)['"]?\]$/,
-        replacement: 'getByTitle',
-      },
-      {
-        messageId: 'unexpectedTestIdQuery',
-        pattern: new RegExp(`^\\[${testIdAttribute}=['"]?(.+?)['"]?\\]`),
-        replacement: 'getByTestId',
-      },
-    ]
+    const patterns = compilePatterns({ testIdAttribute })
 
     return {
       CallExpression(node) {
@@ -74,6 +86,7 @@ export default createRule({
               messageId: pattern.messageId,
               node,
             })
+            return
           }
         }
       },

--- a/src/rules/prefer-native-locators.ts
+++ b/src/rules/prefer-native-locators.ts
@@ -67,19 +67,18 @@ export default createRule({
         const isLocator = isPageMethod(node, 'locator')
         if (!isLocator) return
 
-        // If it's something like `page.locator`, just replace the `.locator` part
-        const start =
-          node.callee.type === 'MemberExpression'
-            ? node.callee.property.range![0]
-            : node.range![0]
-        const end = node.range![1]
-        const rangeToReplace: AST.Range = [start, end]
-
         for (const pattern of patterns) {
           const match = query.match(pattern.pattern)
           if (match) {
             context.report({
               fix(fixer) {
+                const start =
+                  node.callee.type === 'MemberExpression'
+                    ? node.callee.property.range![0]
+                    : node.range![0]
+                const end = node.range![1]
+                const rangeToReplace: AST.Range = [start, end]
+
                 const newText = `${pattern.replacement}("${match[1]}")`
                 return fixer.replaceTextRange(rangeToReplace, newText)
               },

--- a/src/rules/prefer-native-locators.ts
+++ b/src/rules/prefer-native-locators.ts
@@ -16,7 +16,6 @@ export default createRule({
           context.report({
             fix(fixer) {
               const [, label] = query.match(ariaLabelPattern) ?? []
-              // Replace .locator(...) with .getByLabel(...)
               const start =
                 node.callee.type === 'MemberExpression'
                   ? node.callee.property.range![0]
@@ -28,6 +27,26 @@ export default createRule({
               )
             },
             messageId: 'unexpectedLabelQuery',
+            node,
+          })
+        }
+
+        const rolePattern = /^\[role=['"](.+?)['"]\]$/
+        if (query.match(rolePattern)) {
+          context.report({
+            fix(fixer) {
+              const [, role] = query.match(rolePattern) ?? []
+              const start =
+                node.callee.type === 'MemberExpression'
+                  ? node.callee.property.range![0]
+                  : node.range![0]
+              const end = node.range![1]
+              return fixer.replaceTextRange(
+                [start, end],
+                `getByRole("${role}")`,
+              )
+            },
+            messageId: 'unexpectedRoleQuery',
             node,
           })
         }

--- a/src/rules/prefer-native-locators.ts
+++ b/src/rules/prefer-native-locators.ts
@@ -50,9 +50,8 @@ export default createRule({
     return {
       CallExpression(node) {
         if (node.callee.type !== 'MemberExpression') return
-        const method = getStringValue(node.callee.property)
         const query = getStringValue(node.arguments[0])
-        const isLocator = isPageMethod(node, 'locator') || method === 'locator'
+        const isLocator = isPageMethod(node, 'locator')
         if (!isLocator) return
 
         // If it's something like `page.locator`, just replace the `.locator` part

--- a/src/rules/prefer-native-locators.ts
+++ b/src/rules/prefer-native-locators.ts
@@ -70,6 +70,26 @@ export default createRule({
             node,
           })
         }
+
+        const altTextPattern = /^\[alt=['"](.+?)['"]\]$/
+        if (query.match(altTextPattern)) {
+          context.report({
+            fix(fixer) {
+              const [, alt] = query.match(altTextPattern) ?? []
+              const start =
+                node.callee.type === 'MemberExpression'
+                  ? node.callee.property.range![0]
+                  : node.range![0]
+              const end = node.range![1]
+              return fixer.replaceTextRange(
+                [start, end],
+                `getByAltText("${alt}")`,
+              )
+            },
+            messageId: 'unexpectedAltTextQuery',
+            node,
+          })
+        }
       },
     }
   },

--- a/src/rules/prefer-native-locators.ts
+++ b/src/rules/prefer-native-locators.ts
@@ -91,6 +91,26 @@ export default createRule({
           })
         }
 
+        const titlePattern = /^\[title=['"](.+?)['"]\]$/
+        if (query.match(titlePattern)) {
+          context.report({
+            fix(fixer) {
+              const [, title] = query.match(titlePattern) ?? []
+              const start =
+                node.callee.type === 'MemberExpression'
+                  ? node.callee.property.range![0]
+                  : node.range![0]
+              const end = node.range![1]
+              return fixer.replaceTextRange(
+                [start, end],
+                `getByTitle("${title}")`,
+              )
+            },
+            messageId: 'unexpectedTitleQuery',
+            node,
+          })
+        }
+
         // TODO: Add support for custom test ID attribute
         const testIdAttributeName = 'data-testid'
         const testIdPattern = new RegExp(
@@ -131,6 +151,7 @@ export default createRule({
       unexpectedPlaceholderQuery: 'Use .getByPlaceholder() instead',
       unexpectedRoleQuery: 'Use .getByRole() instead',
       unexpectedTestIdQuery: 'Use .getByTestId() instead',
+      unexpectedTitleQuery: 'Use .getByTitle() instead',
     },
     schema: [],
     type: 'suggestion',

--- a/src/rules/prefer-native-locators.ts
+++ b/src/rules/prefer-native-locators.ts
@@ -88,12 +88,12 @@ export default createRule({
     },
     fixable: 'code',
     messages: {
-      unexpectedAltTextQuery: 'Use .getByAltText() instead',
-      unexpectedLabelQuery: 'Use .getByLabel() instead',
-      unexpectedPlaceholderQuery: 'Use .getByPlaceholder() instead',
-      unexpectedRoleQuery: 'Use .getByRole() instead',
-      unexpectedTestIdQuery: 'Use .getByTestId() instead',
-      unexpectedTitleQuery: 'Use .getByTitle() instead',
+      unexpectedAltTextQuery: 'Use getByAltText() instead',
+      unexpectedLabelQuery: 'Use getByLabel() instead',
+      unexpectedPlaceholderQuery: 'Use getByPlaceholder() instead',
+      unexpectedRoleQuery: 'Use getByRole() instead',
+      unexpectedTestIdQuery: 'Use getByTestId() instead',
+      unexpectedTitleQuery: 'Use getByTitle() instead',
     },
     schema: [
       {

--- a/src/rules/prefer-native-locators.ts
+++ b/src/rules/prefer-native-locators.ts
@@ -50,6 +50,26 @@ export default createRule({
             node,
           })
         }
+
+        const placeholderPattern = /^\[placeholder=['"](.+?)['"]\]$/
+        if (query.match(placeholderPattern)) {
+          context.report({
+            fix(fixer) {
+              const [, placeholder] = query.match(placeholderPattern) ?? []
+              const start =
+                node.callee.type === 'MemberExpression'
+                  ? node.callee.property.range![0]
+                  : node.range![0]
+              const end = node.range![1]
+              return fixer.replaceTextRange(
+                [start, end],
+                `getByPlaceholder("${placeholder}")`,
+              )
+            },
+            messageId: 'unexpectedPlaceholderQuery',
+            node,
+          })
+        }
       },
     }
   },

--- a/src/rules/prefer-native-locators.ts
+++ b/src/rules/prefer-native-locators.ts
@@ -64,8 +64,7 @@ export default createRule({
       CallExpression(node) {
         if (node.callee.type !== 'MemberExpression') return
         const query = getStringValue(node.arguments[0])
-        const isLocator = isPageMethod(node, 'locator')
-        if (!isLocator) return
+        if (!isPageMethod(node, 'locator')) return
 
         for (const pattern of patterns) {
           const match = query.match(pattern.pattern)

--- a/src/rules/prefer-native-locators.ts
+++ b/src/rules/prefer-native-locators.ts
@@ -18,32 +18,32 @@ export default createRule({
     const patterns: Array<Pattern> = [
       {
         messageId: 'unexpectedLabelQuery',
-        pattern: /^\[aria-label=['"](.+?)['"]\]$/,
+        pattern: /^\[aria-label=['"]?(.+?)['"]?\]$/,
         replacement: 'getByLabel',
       },
       {
         messageId: 'unexpectedRoleQuery',
-        pattern: /^\[role=['"](.+?)['"]\]$/,
+        pattern: /^\[role=['"]?(.+?)['"]?\]$/,
         replacement: 'getByRole',
       },
       {
         messageId: 'unexpectedPlaceholderQuery',
-        pattern: /^\[placeholder=['"](.+?)['"]\]$/,
+        pattern: /^\[placeholder=['"]?(.+?)['"]?\]$/,
         replacement: 'getByPlaceholder',
       },
       {
         messageId: 'unexpectedAltTextQuery',
-        pattern: /^\[alt=['"](.+?)['"]\]$/,
+        pattern: /^\[alt=['"]?(.+?)['"]?\]$/,
         replacement: 'getByAltText',
       },
       {
         messageId: 'unexpectedTitleQuery',
-        pattern: /^\[title=['"](.+?)['"]\]$/,
+        pattern: /^\[title=['"]?(.+?)['"]?\]$/,
         replacement: 'getByTitle',
       },
       {
         messageId: 'unexpectedTestIdQuery',
-        pattern: new RegExp(`^\\[${testIdAttribute}=['"](.+?)['"]\\]`),
+        pattern: new RegExp(`^\\[${testIdAttribute}=['"]?(.+?)['"]?\\]`),
         replacement: 'getByTestId',
       },
     ]

--- a/src/rules/prefer-native-locators.ts
+++ b/src/rules/prefer-native-locators.ts
@@ -1,3 +1,4 @@
+import { AST } from 'eslint'
 import { getStringValue, isPageMethod } from '../utils/ast'
 import { createRule } from '../utils/createRule'
 
@@ -60,7 +61,7 @@ export default createRule({
             ? node.callee.property.range![0]
             : node.range![0]
         const end = node.range![1]
-        const rangeToReplace: [number, number] = [start, end]
+        const rangeToReplace: AST.Range = [start, end]
 
         for (const pattern of patterns) {
           const match = query.match(pattern.pattern)

--- a/src/rules/prefer-native-locators.ts
+++ b/src/rules/prefer-native-locators.ts
@@ -5,6 +5,11 @@ export default createRule({
   create(context) {
     return {
       CallExpression(node) {
+        const { testIdAttribute } = {
+          testIdAttribute: 'data-testid',
+          ...((context.options?.[0] as Record<string, unknown>) ?? {}),
+        }
+
         if (node.callee.type !== 'MemberExpression') return
         const method = getStringValue(node.callee.property)
         const query = getStringValue(node.arguments[0])
@@ -84,10 +89,8 @@ export default createRule({
           })
         }
 
-        // TODO: Add support for custom test ID attribute
-        const testIdAttributeName = 'data-testid'
         const testIdPattern = new RegExp(
-          `^\\[${testIdAttributeName}=['"](.+?)['"]\\]`,
+          `^\\[${testIdAttribute}=['"](.+?)['"]\\]`,
         )
         const testIdMatch = query.match(testIdPattern)
         if (testIdMatch) {
@@ -119,7 +122,18 @@ export default createRule({
       unexpectedTestIdQuery: 'Use .getByTestId() instead',
       unexpectedTitleQuery: 'Use .getByTitle() instead',
     },
-    schema: [],
+    schema: [
+      {
+        additionalProperties: false,
+        properties: {
+          testIdAttribute: {
+            default: 'data-testid',
+            type: 'string',
+          },
+        },
+        type: 'object',
+      },
+    ],
     type: 'suggestion',
   },
 })


### PR DESCRIPTION
- Closes #203 

This PR adds a rule for suggesting usage of built-in locators when there is an equivalent to a custom locator that is being used. Rather than trying to rewrite all possible custom locators, I've focused on a cases that are auto-fixable and should have a low false positive rate. So, more complex locators (including text queries) were not included in this initial PR. We should expand this rule to accommodate for other cases in the future.