### PR TITLE
Apply title rules to test.step

### DIFF
--- a/docs/rules/valid-title.md
+++ b/docs/rules/valid-title.md
@@ -143,6 +143,7 @@ test.describe('foo', () => {
 ```ts
 interface Options {
   ignoreSpaces?: boolean
+  ignoreTypeOfStepName?: boolean
   ignoreTypeOfTestName?: boolean
   ignoreTypeOfDescribeName?: boolean
   disallowedWords?: string[]
@@ -156,6 +157,13 @@ interface Options {
 Default: `false`
 
 When enabled, the leading and trailing spaces won't be checked.
+
+#### `ignoreTypeOfStepName`
+
+Default: `true`
+
+When enabled, the type of the first argument to `test.step` blocks won't be
+checked.
 
 #### `ignoreTypeOfDescribeName`
 

--- a/src/rules/valid-title.test.ts
+++ b/src/rules/valid-title.test.ts
@@ -52,6 +52,18 @@ runRuleTester('valid-title', rule, {
       options: [{ disallowedWords: ['descriptive'] }],
     },
     {
+      code: 'test(`that the value is set properly`, function () {})',
+      errors: [
+        {
+          column: 6,
+          data: { word: 'properly' },
+          line: 1,
+          messageId: 'disallowedWord',
+        },
+      ],
+      options: [{ disallowedWords: ['properly'] }],
+    },
+    {
       code: 'test.step(`that the value is set properly`, function () {})',
       errors: [
         {

--- a/src/rules/valid-title.test.ts
+++ b/src/rules/valid-title.test.ts
@@ -52,10 +52,10 @@ runRuleTester('valid-title', rule, {
       options: [{ disallowedWords: ['descriptive'] }],
     },
     {
-      code: 'test(`that the value is set properly`, function () {})',
+      code: 'test.step(`that the value is set properly`, function () {})',
       errors: [
         {
-          column: 6,
+          column: 11,
           data: { word: 'properly' },
           line: 1,
           messageId: 'disallowedWord',
@@ -142,7 +142,9 @@ runRuleTester('mustMatch & mustNotMatch options', rule, {
           });
 
           test.describe('e2e tests #e4e', () => {
-            test('is another test #e2e #playwright4life', () => {});
+            test('is another test #e2e #playwright4life', () => {
+              test.step('#wow', () => {});
+            });
           });
         });
       `,
@@ -165,6 +167,15 @@ runRuleTester('mustMatch & mustNotMatch options', rule, {
           line: 9,
           messageId: 'mustNotMatch',
         },
+        {
+          column: 17,
+          data: {
+            functionName: 'step',
+            pattern: /(?:#(?!unit|e2e))\w+/u,
+          },
+          line: 10,
+          messageId: 'mustNotMatch',
+        },
       ],
       options: [
         {
@@ -183,7 +194,9 @@ runRuleTester('mustMatch & mustNotMatch options', rule, {
           });
 
           test.describe('e2e tests #e4e', () => {
-            test('is another test #e2e #playwright4life', () => {});
+            test('is another test #e2e #playwright4life', () => {
+              test.step('#wow', () => {});
+            });
           });
         });
       `,
@@ -206,6 +219,15 @@ runRuleTester('mustMatch & mustNotMatch options', rule, {
             pattern: /(?:#(?!unit|e2e))\w+/u,
           },
           line: 9,
+          messageId: 'mustNotMatchCustom',
+        },
+        {
+          column: 17,
+          data: {
+            message: 'Please include "#unit" or "#e2e" in titles',
+            pattern: /(?:#(?!unit|e2e))\w+/u,
+          },
+          line: 10,
           messageId: 'mustNotMatchCustom',
         },
       ],
@@ -232,7 +254,9 @@ runRuleTester('mustMatch & mustNotMatch options', rule, {
           });
 
           test.describe('e2e tests #e4e', () => {
-            test('is another test #e2e #playwright4life', () => {});
+            test('is another test #e2e #playwright4life', () => {
+              test.step('#wow', () => {});
+            });
           });
         });
       `,
@@ -264,7 +288,9 @@ runRuleTester('mustMatch & mustNotMatch options', rule, {
           });
 
           test.describe('e2e tests #e4e', () => {
-            test('is another test #e2e #playwright4life', () => {});
+            test('is another test #e2e #playwright4life', () => {
+              test.step('#wow', () => {});
+            });
           });
         });
       `,
@@ -302,7 +328,9 @@ runRuleTester('mustMatch & mustNotMatch options', rule, {
           });
 
           test.describe('e2e tests #e4e', () => {
-            test('is another test #e2e #playwright4life', () => {});
+            test('is another test #e2e #playwright4life', () => {
+              test.step('#wow', () => {});
+            });
           });
         });
       `,
@@ -334,7 +362,9 @@ runRuleTester('mustMatch & mustNotMatch options', rule, {
           });
 
           test.describe('e2e tests #e4e', () => {
-            test('is another test #e2e #playwright4life', () => {});
+            test('is another test #e2e #playwright4life', () => {
+              test.step('#wow', () => {});
+            });
           });
         });
       `,
@@ -407,6 +437,23 @@ runRuleTester('mustMatch & mustNotMatch options', rule, {
       ],
       options: [
         { mustMatch: { describe: /#(?:unit|integration|e2e)/u.source } },
+      ],
+    },
+    {
+      code: 'test.step("the test", () => {});',
+      errors: [
+        {
+          column: 11,
+          data: {
+            functionName: 'step',
+            pattern: /#(?:unit|integration|e2e)/u,
+          },
+          line: 1,
+          messageId: 'mustMatch',
+        },
+      ],
+      options: [
+        { mustMatch: { step: /#(?:unit|integration|e2e)/u.source } },
       ],
     },
     {
@@ -499,6 +546,12 @@ runRuleTester('mustMatch & mustNotMatch options', rule, {
     },
     {
       code: 'test("correctly sets the value", () => {});',
+      options: [
+        { mustMatch: { describe: /#(?:unit|integration|e2e)/u.source } },
+      ],
+    },
+    {
+      code: 'test.step("correctly sets the value", () => {});',
       options: [
         { mustMatch: { describe: /#(?:unit|integration|e2e)/u.source } },
       ],
@@ -657,6 +710,17 @@ runRuleTester('title-must-be-string', rule, {
         },
       ],
     },
+    {
+      code: 'test.step(123, () => {});',
+      errors: [
+        {
+          column: 11,
+          line: 1,
+          messageId: 'titleMustBeString',
+        },
+      ],
+      options: [{ ignoreTypeOfStepName: false }],
+    },
     // Global aliases
     {
       code: 'it(String(/.+/), () => {});',
@@ -685,6 +749,7 @@ runRuleTester('title-must-be-string', rule, {
     'test.describe.skip("is a string", () => {});',
     'test.describe.skip(`${myFunc} is a string`, () => {});',
     'test.describe("is a string", () => {});',
+    'test.step(123, () => {});',
     {
       code: 'test.describe(String(/.+/), () => {});',
       options: [{ ignoreTypeOfDescribeName: true }],
@@ -811,6 +876,17 @@ runRuleTester('no-empty-title', rule, {
         },
       ],
     },
+    {
+      code: 'test.step(``, function () {})',
+      errors: [
+        {
+          column: 1,
+          data: { functionName: 'step' },
+          line: 1,
+          messageId: 'emptyTitle',
+        },
+      ],
+    },
     // Global aliases
     {
       code: 'it.describe("", function () {})',
@@ -840,6 +916,7 @@ runRuleTester('no-empty-title', rule, {
     'test.skip(`foo`, function () {})',
     'test(`${foo}`, function () {})',
     'test.fixme(`${foo}`, function () {})',
+    'test.step(`${foo}`, function () {})',
     // Global aliases
     {
       code: 'test.describe()',
@@ -970,6 +1047,21 @@ runRuleTester('no-accidental-space', rule, {
       output: 'test("foo", function () {})',
     },
     {
+      code: 'test.step(` foo bar bang  `, function () {})',
+      errors: [{ column: 11, line: 1, messageId: 'accidentalSpace' }],
+      output: 'test.step(`foo bar bang`, function () {})',
+    },
+    {
+      code: 'test.step(" foo", function () {})',
+      errors: [{ column: 11, line: 1, messageId: 'accidentalSpace' }],
+      output: 'test.step("foo", function () {})',
+    },
+    {
+      code: 'test.step(" foo  ", function () {})',
+      errors: [{ column: 11, line: 1, messageId: 'accidentalSpace' }],
+      output: 'test.step("foo", function () {})',
+    },
+    {
       code: javascript`
         test.describe(' foo', () => {
           test('bar', () => {})
@@ -1013,6 +1105,8 @@ runRuleTester('no-accidental-space', rule, {
     'test("foo", function () {})',
     'test.describe()',
     'test.describe("foo", function () {})',
+    'test.step()',
+    'test.step("foo", function () {})',
     'test.only()',
     'test.only("foo", function () {})',
     javascript`
@@ -1135,6 +1229,39 @@ runRuleTester('no-duplicate-prefix test', rule, {
   ],
 })
 
+runRuleTester('no-duplicate-prefix step', rule, {
+  invalid: [
+    {
+      code: 'test.step("step foo", function () {})',
+      errors: [{ column: 11, line: 1, messageId: 'duplicatePrefix' }],
+      output: 'test.step("foo", function () {})',
+    },
+    {
+      code: 'test.step("step foo", function () {})',
+      errors: [{ column: 11, line: 1, messageId: 'duplicatePrefix' }],
+      output: 'test.step("foo", function () {})',
+    },
+    {
+      code: 'test.step("step foo", function () {})',
+      errors: [{ column: 11, line: 1, messageId: 'duplicatePrefix' }],
+      output: 'test.step("foo", function () {})',
+    },
+    {
+      code: "test.step('step foo', function () {})",
+      errors: [{ column: 11, line: 1, messageId: 'duplicatePrefix' }],
+      output: "test.step('foo', function () {})",
+    },
+    {
+      code: 'test.step(`step foo`, function () {})',
+      errors: [{ column: 11, line: 1, messageId: 'duplicatePrefix' }],
+      output: 'test.step(`foo`, function () {})',
+    }
+  ],
+  valid: [
+    'test.step("foo", function () {})',
+  ],
+})
+
 runRuleTester('no-duplicate-prefix nested', rule, {
   invalid: [
     {
@@ -1173,6 +1300,23 @@ runRuleTester('no-duplicate-prefix nested', rule, {
       output: javascript`
         test.describe('foo', () => {
           test('bar', () => {})
+        })
+      `,
+    },
+    {
+      code: javascript`
+        test.describe('foo', () => {
+          test('bar', () => {
+            test.step('step foobar', () => {})
+          })
+        })
+      `,
+      errors: [{ column: 15, line: 3, messageId: 'duplicatePrefix' }],
+      output: javascript`
+        test.describe('foo', () => {
+          test('bar', () => {
+            test.step('foobar', () => {})
+          })
         })
       `,
     },

--- a/src/rules/valid-title.test.ts
+++ b/src/rules/valid-title.test.ts
@@ -452,9 +452,7 @@ runRuleTester('mustMatch & mustNotMatch options', rule, {
           messageId: 'mustMatch',
         },
       ],
-      options: [
-        { mustMatch: { step: /#(?:unit|integration|e2e)/u.source } },
-      ],
+      options: [{ mustMatch: { step: /#(?:unit|integration|e2e)/u.source } }],
     },
     {
       code: 'test.describe.skip("the test", () => {});',
@@ -1255,11 +1253,9 @@ runRuleTester('no-duplicate-prefix step', rule, {
       code: 'test.step(`step foo`, function () {})',
       errors: [{ column: 11, line: 1, messageId: 'duplicatePrefix' }],
       output: 'test.step(`foo`, function () {})',
-    }
+    },
   ],
-  valid: [
-    'test.step("foo", function () {})',
-  ],
+  valid: ['test.step("foo", function () {})'],
 })
 
 runRuleTester('no-duplicate-prefix nested', rule, {

--- a/src/rules/valid-title.ts
+++ b/src/rules/valid-title.ts
@@ -44,8 +44,8 @@ const compileMatcherPatterns = (
 
     return {
       describe: compiledMatcher,
-      test: compiledMatcher,
       step: compiledMatcher,
+      test: compiledMatcher,
     }
   }
 
@@ -53,8 +53,8 @@ const compileMatcherPatterns = (
     describe: matchers.describe
       ? compileMatcherPattern(matchers.describe)
       : null,
-    test: matchers.test ? compileMatcherPattern(matchers.test) : null,
     step: matchers.step ? compileMatcherPattern(matchers.step) : null,
+    test: matchers.test ? compileMatcherPattern(matchers.test) : null,
   }
 }
 
@@ -69,14 +69,14 @@ const MatcherAndMessageSchema = {
   type: 'array',
 } as const
 
-type MatcherGroups = 'describe' | 'test' | 'step'
+type MatcherGroups = 'describe' | 'step' | 'test'
 
 interface Options {
   disallowedWords?: string[]
   ignoreSpaces?: boolean
   ignoreTypeOfDescribeName?: boolean
-  ignoreTypeOfTestName?: boolean
   ignoreTypeOfStepName?: boolean
+  ignoreTypeOfTestName?: boolean
   mustMatch?:
     | Partial<Record<MatcherGroups, string | MatcherAndMessage>>
     | MatcherAndMessage
@@ -94,8 +94,8 @@ export default createRule({
       disallowedWords = [],
       ignoreSpaces = false,
       ignoreTypeOfDescribeName = false,
-      ignoreTypeOfTestName = false,
       ignoreTypeOfStepName = true,
+      ignoreTypeOfTestName = false,
       mustMatch,
       mustNotMatch,
     } = opts
@@ -290,12 +290,12 @@ export default createRule({
             default: false,
             type: 'boolean',
           },
-          ignoreTypeOfTestName: {
-            default: false,
-            type: 'boolean',
-          },
           ignoreTypeOfStepName: {
             default: true,
+            type: 'boolean',
+          },
+          ignoreTypeOfTestName: {
+            default: false,
             type: 'boolean',
           },
         },

--- a/src/rules/valid-title.ts
+++ b/src/rules/valid-title.ts
@@ -54,7 +54,7 @@ const compileMatcherPatterns = (
       ? compileMatcherPattern(matchers.describe)
       : null,
     test: matchers.test ? compileMatcherPattern(matchers.test) : null,
-    step: matchers.step ? compileMatcherPattern(matchers.step) : null
+    step: matchers.step ? compileMatcherPattern(matchers.step) : null,
   }
 }
 
@@ -110,7 +110,11 @@ export default createRule({
     return {
       CallExpression(node) {
         const call = parseFnCall(context, node)
-        if (call?.type !== 'test' && call?.type !== 'describe' && call?.type !== 'step') {
+        if (
+          call?.type !== 'test' &&
+          call?.type !== 'describe' &&
+          call?.type !== 'step'
+        ) {
           return
         }
 
@@ -293,7 +297,7 @@ export default createRule({
           ignoreTypeOfStepName: {
             default: true,
             type: 'boolean',
-          }
+          },
         },
         type: 'object',
       },


### PR DESCRIPTION
Updated `valid-title` rule to apply to `test.step` commands.