### PR TITLE
Check if page methods are missing await (`missing-playwright-await`)

### DIFF
--- a/docs/rules/missing-playwright-await.md
+++ b/docs/rules/missing-playwright-await.md
@@ -9,6 +9,7 @@ Example of **incorrect** code for this rule:
 ```javascript
 expect(page).toMatchText('text')
 expect.poll(() => foo).toBe(true)
+page.goto('https://example.com')
 
 test.step('clicks the button', async () => {
   await page.click('button')
@@ -20,6 +21,7 @@ Example of **correct** code for this rule:
 ```javascript
 await expect(page).toMatchText('text')
 await expect.poll(() => foo).toBe(true)
+await page.goto('https://example.com')
 
 await test.step('clicks the button', async () => {
   await page.click('button')

--- a/src/rules/missing-playwright-await.test.ts
+++ b/src/rules/missing-playwright-await.test.ts
@@ -247,6 +247,21 @@ runRuleTester('missing-playwright-await', rule, {
         },
       },
     },
+    // Page methods
+    {
+      code: `page.goto('https://example.com')`,
+      errors: [
+        { column: 1, endColumn: 10, endLine: 1, line: 1, messageId: 'page' },
+      ],
+      output: `await page.goto('https://example.com')`,
+    },
+    {
+      code: test(`page.goto('https://example.com')`),
+      errors: [
+        { column: 28, endColumn: 37, endLine: 1, line: 1, messageId: 'page' },
+      ],
+      output: test(`await page.goto('https://example.com')`),
+    },
   ],
   valid: [
     // Basic
@@ -368,5 +383,8 @@ runRuleTester('missing-playwright-await', rule, {
         },
       },
     },
+    // Page methods
+    { code: `await page.goto('https://example.com')` },
+    { code: test(`await page.goto('https://example.com')`) },
   ],
 })

--- a/src/rules/missing-playwright-await.test.ts
+++ b/src/rules/missing-playwright-await.test.ts
@@ -385,6 +385,12 @@ runRuleTester('missing-playwright-await', rule, {
     },
     // Page methods
     { code: `await page.goto('https://example.com')` },
-    { code: test(`await page.goto('https://example.com')`) },
+    { code: `await page.title()` },
+    // Other page methods are ignored
+    { code: `page.frames()` },
+    // Other methods with the same name are ignored
+    { code: `randomObject.title()` },
+    // Does not need to be awaited when returned
+    { code: `() => { return page.content() }` },
   ],
 })

--- a/src/rules/missing-playwright-await.ts
+++ b/src/rules/missing-playwright-await.ts
@@ -57,7 +57,75 @@ const playwrightTestMatchers = [
   'toBeInViewport',
 ]
 
-const pageMethods = new Set(['goto'])
+const pageMethods = new Set([
+  '$', // deprecated
+  '$$', // deprecated
+  '$eval', // deprecated
+  '$$eval', // deprecated
+  'addInitScript',
+  'addLocatorHandler',
+  'addScriptTag',
+  'addStyleTag',
+  'bringToFront',
+  'check', // deprecated
+  'click', // deprecated
+  'close',
+  'content',
+  'dblclick', // deprecated
+  'dispatchEvent', // deprecated
+  'dragAndDrop',
+  'emulateMedia',
+  'evaluate',
+  'evaluateHandle',
+  'exposeBinding',
+  'exposeFunction',
+  'fill', // deprecated
+  'focus', // deprecated
+  'getAttribute', // deprecated
+  'goBack',
+  'goForward',
+  'goto',
+  'hover', // deprecated
+  'innerHTML', // deprecated
+  'innerText', // deprecated
+  'inputValue', // deprecated
+  'isChecked', // deprecated
+  'isDisabled', // deprecated
+  'isEditable', // deprecated
+  'isEnabled', // deprecated
+  'isHidden', // deprecated
+  'isVisible', // deprecated
+  'opener',
+  'pause',
+  'pdf',
+  'press', // deprecated
+  'reload',
+  'removeLocatorHandler',
+  'route',
+  'routeFromHAR',
+  'screenshot',
+  'selectOption', // deprecated
+  'setChecked', // deprecated
+  'setContent',
+  'setExtraHTTPHeaders',
+  'setInputFiles', // deprecated
+  'setViewportSize',
+  'tap', // deprecated
+  'textContent', // deprecated
+  'title',
+  'type', // deprecated
+  'unroute',
+  'unrouteAll',
+  'waitForEvent',
+  'waitForFunction',
+  'waitForLoadState',
+  'waitForNavigation', // deprecated
+  'waitForRequest',
+  'waitForResponse',
+  'waitForSelector', // deprecated
+  'waitForTimeout', // deprecated
+  'waitForURL',
+])
 
 function getReportNode(node: ESTree.Node) {
   const parent = getParent(node)

--- a/src/utils/ast.ts
+++ b/src/utils/ast.ts
@@ -116,10 +116,17 @@ export function dig(node: ESTree.Node, identifier: string | RegExp): boolean {
     : false
 }
 
+export function isPage(node: ESTree.CallExpression) {
+  return (
+    node.callee.type === 'MemberExpression' &&
+    dig(node.callee.object, /(^(page|frame)|(Page|Frame)$)/)
+  )
+}
+
 export function isPageMethod(node: ESTree.CallExpression, name: string) {
   return (
     node.callee.type === 'MemberExpression' &&
-    dig(node.callee.object, /(^(page|frame)|(Page|Frame)$)/) &&
+    isPage(node) &&
     isPropertyAccessor(node.callee, name)
   )
 }


### PR DESCRIPTION
- Part of https://github.com/playwright-community/eslint-plugin-playwright/issues/159

This adds support for checking if `Page` methods are properly awaited, as part of the `missing-playwright-await` rule.