### PR TITLE
fix(expect-expert): report on test function identifier rather than body

### DIFF
--- a/src/rules/expect-expect.test.ts
+++ b/src/rules/expect-expect.test.ts
@@ -5,7 +5,7 @@ runRuleTester('expect-expect', rule, {
   invalid: [
     {
       code: 'test("should fail", () => {});',
-      errors: [{ messageId: 'noAssertions', type: 'Identifier', }],
+      errors: [{ messageId: 'noAssertions', type: 'Identifier' }],
     },
     {
       code: 'test.skip("should fail", () => {});',

--- a/src/rules/expect-expect.test.ts
+++ b/src/rules/expect-expect.test.ts
@@ -5,11 +5,11 @@ runRuleTester('expect-expect', rule, {
   invalid: [
     {
       code: 'test("should fail", () => {});',
-      errors: [{ messageId: 'noAssertions' }],
+      errors: [{ messageId: 'noAssertions', type: 'Identifier', }],
     },
     {
       code: 'test.skip("should fail", () => {});',
-      errors: [{ messageId: 'noAssertions' }],
+      errors: [{ messageId: 'noAssertions', type: 'MemberExpression' }],
     },
     {
       code: javascript`
@@ -17,7 +17,7 @@ runRuleTester('expect-expect', rule, {
           await assertCustomCondition(page)
         })
       `,
-      errors: [{ messageId: 'noAssertions' }],
+      errors: [{ messageId: 'noAssertions', type: 'Identifier' }],
     },
     {
       code: javascript`
@@ -25,13 +25,13 @@ runRuleTester('expect-expect', rule, {
           await assertCustomCondition(page)
         })
       `,
-      errors: [{ messageId: 'noAssertions' }],
+      errors: [{ messageId: 'noAssertions', type: 'Identifier' }],
       name: 'Custom assert function',
       options: [{ assertFunctionNames: ['wayComplexCustomCondition'] }],
     },
     {
       code: 'it("should pass", () => hi(true).toBeDefined())',
-      errors: [{ messageId: 'noAssertions' }],
+      errors: [{ messageId: 'noAssertions', type: 'Identifier' }],
       name: 'Global aliases',
       settings: {
         playwright: {

--- a/src/rules/expect-expect.ts
+++ b/src/rules/expect-expect.ts
@@ -40,7 +40,7 @@ export default createRule({
       },
       'Program:exit'() {
         unchecked.forEach((node) => {
-          context.report({ messageId: 'noAssertions', node })
+          context.report({ messageId: 'noAssertions', node: node.callee })
         })
       },
     }


### PR DESCRIPTION
Fixes #336

| BEFORE | AFTER |
|--------|--------|
| <img width="643" alt="Screenshot 2024-11-28 at 5 04 47 PM" src="https://github.com/user-attachments/assets/9b34f3e2-ef30-4631-89e1-800536425ddc"> | <img width="924" alt="Screenshot 2024-11-28 at 5 04 02 PM" src="https://github.com/user-attachments/assets/fad9e1e7-f72a-4631-9414-4182936fe42f"> | 