### PR TITLE
fix: remove workspaces and other dev fields from published package.json

### DIFF
--- a/.cursor/rules/eslint-plugin-playwright.mdc
+++ b/.cursor/rules/eslint-plugin-playwright.mdc
@@ -1,0 +1,20 @@
+---
+alwaysApply: true
+---
+
+## Pull Requests
+
+- When creating pull requests, add the `cursor` label to the pull request.
+
+## Commits
+
+- This project uses semantic-release to automatically publish new versions of
+  the package.
+- When creating commits, use the following format:
+  - `feat: add new feature`
+  - `fix: fix bug`
+  - `chore: update dependencies`
+  - `docs: update documentation`
+  - `refactor: refactor code`
+  - `test: add tests`
+  - `style: update styles`

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,26 +18,8 @@ jobs:
           node-version: '20.x'
       - name: Build
         run: pnpm build
-      - name: Clean package.json for publishing
-        run: |
-          # Create backup of original package.json
-          cp package.json package.json.backup
-          # Remove development-only fields
-          node -e "
-            const pkg = JSON.parse(require('fs').readFileSync('package.json', 'utf8'));
-            delete pkg.workspaces;
-            delete pkg.packageManager;
-            delete pkg.scripts;
-            delete pkg.devDependencies;
-            require('fs').writeFileSync('package.json', JSON.stringify(pkg, null, 2) + '\n');
-          "
       - name: Release
         run: pnpm semantic-release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.npm_token }}
-      - name: Restore package.json
-        if: always()
-        run: |
-          # Restore original package.json
-          mv package.json.backup package.json

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,8 +18,26 @@ jobs:
           node-version: '20.x'
       - name: Build
         run: pnpm build
+      - name: Clean package.json for publishing
+        run: |
+          # Create backup of original package.json
+          cp package.json package.json.backup
+          # Remove development-only fields
+          node -e "
+            const pkg = JSON.parse(require('fs').readFileSync('package.json', 'utf8'));
+            delete pkg.workspaces;
+            delete pkg.packageManager;
+            delete pkg.scripts;
+            delete pkg.devDependencies;
+            require('fs').writeFileSync('package.json', JSON.stringify(pkg, null, 2) + '\n');
+          "
       - name: Release
         run: pnpm semantic-release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.npm_token }}
+      - name: Restore package.json
+        if: always()
+        run: |
+          # Restore original package.json
+          mv package.json.backup package.json

--- a/.releaserc.json
+++ b/.releaserc.json
@@ -1,3 +1,10 @@
 {
-  "extends": "@mskelton/semantic-release-config"
+  "extends": "@mskelton/semantic-release-config",
+  "plugins": [
+    "@semantic-release/commit-analyzer",
+    "@semantic-release/release-notes-generator",
+    "@anolilab/semantic-release-clean-package-json",
+    "@semantic-release/npm",
+    "@semantic-release/github"
+  ]
 }

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "globals": "^13.23.0"
   },
   "devDependencies": {
+    "@anolilab/semantic-release-clean-package-json": "^3.0.2",
     "@mskelton/eslint-config": "^9.0.1",
     "@mskelton/semantic-release-config": "^1.0.1",
     "@types/estree": "^1.0.6",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,6 +12,9 @@ importers:
         specifier: ^13.23.0
         version: 13.23.0
     devDependencies:
+      '@anolilab/semantic-release-clean-package-json':
+        specifier: ^3.0.2
+        version: 3.0.2
       '@mskelton/eslint-config':
         specifier: ^9.0.1
         version: 9.0.1(eslint@9.13.0)(typescript@5.2.2)(vitest@1.3.1)
@@ -69,6 +72,17 @@ importers:
         version: 20.11.17
 
 packages:
+
+  /@anolilab/semantic-release-clean-package-json@3.0.2:
+    resolution: {integrity: sha512-BffuRvhE6xC8ts831ZM8XsJkEhdWV/W7kjuQIxehdztjgaJee1dc2k/MnBFT2fPSHHoLVbHHrG16Zp6a6rm31w==}
+    engines: {node: '>=20.8.1'}
+    dependencies:
+      '@semantic-release/error': 4.0.0
+      '@visulima/fs': 3.1.5
+      '@visulima/path': 1.4.0
+    transitivePeerDependencies:
+      - yaml
+    dev: true
 
   /@babel/code-frame@7.22.13:
     resolution: {integrity: sha512-XktuhWlJ5g+3TJXc5upd9Ks1HutSArik6jf2eAjYFyIOf4ej3RN+184cZbzDvbPnuTJIUhPKKJE3cIsYTiAT3w==}
@@ -1368,6 +1382,25 @@ packages:
     dependencies:
       '@typescript-eslint/types': 8.11.0
       eslint-visitor-keys: 3.4.3
+    dev: true
+
+  /@visulima/fs@3.1.5:
+    resolution: {integrity: sha512-0m2iVLB/rxwmmuyuC7yTikzV45osj38Lrp+WYKWq8kdtdxDnd0NXDL+MHB4qv1wp+wmy+iOiaXQcd98aZuc1XQ==}
+    engines: {node: '>=18.0.0 <=23.x'}
+    os: [darwin, linux, win32]
+    peerDependencies:
+      yaml: ^2.7.0
+    peerDependenciesMeta:
+      yaml:
+        optional: true
+    dependencies:
+      '@visulima/path': 1.4.0
+    dev: true
+
+  /@visulima/path@1.4.0:
+    resolution: {integrity: sha512-lhtA4woh4KsXWyn3BJ/qYE/HSt+agsHeSGb7j3UeHpRyf3R4ErObR25snvt+Rc4Xlqb1T68U38wjqZ2YpmUGNw==}
+    engines: {node: '>=18.0.0 <=23.x'}
+    os: [darwin, linux, win32]
     dev: true
 
   /@vitest/expect@1.3.1:


### PR DESCRIPTION
Fixes #360 - removes workspaces and other development-only fields from published package.json to prevent Yarn v1 warnings