### PR TITLE
#373 - Allow valid locators declared as variables

### DIFF
--- a/src/rules/no-raw-locators.test.ts
+++ b/src/rules/no-raw-locators.test.ts
@@ -10,6 +10,14 @@ runRuleTester('no-raw-locators', rule, {
       errors: [{ column: 34, endColumn: 48, line: 1, messageId }],
     },
     {
+      code: test('const locator = await page.locator()'),
+      errors: [{ column: 50, endColumn: 64, line: 1, messageId }],
+    },
+    {
+      code: test('let locator = await page.locator()'),
+      errors: [{ column: 48, endColumn: 62, line: 1, messageId }],
+    },
+    {
       code: test('await this.page.locator()'),
       errors: [{ column: 34, endColumn: 53, line: 1, messageId }],
     },
@@ -37,7 +45,18 @@ runRuleTester('no-raw-locators', rule, {
       ),
       errors: [{ column: 77, endColumn: 100, line: 1, messageId }],
     },
-
+    {
+      code: test(
+        'const button = page.locator(); page.locator(button)',
+      ),
+      errors: [{ column: 43, endColumn: 57, line: 1, messageId }],
+    },
+    {
+      code: test(
+        'let button = page.locator(); page.locator(button)',
+      ),
+      errors: [{ column: 41, endColumn: 55, line: 1, messageId }],
+    },
     // Allowed
     {
       code: test('await page.locator("[aria-busy=false]")'),
@@ -79,6 +98,14 @@ runRuleTester('no-raw-locators', rule, {
 
     test(
       'const section = page.getByRole("section"); section.getByRole("button")',
+    ),
+
+    // Variable references with proper locators
+    test(
+      'const button = page.getByRole("button", { name: "common button" }); page.locator(button)',
+    ),
+    test(
+      'const firstButton = page.getByRole("region", { name: "first" }).locator(button); const secondButton = page.getByRole("region", { name: "second" }).locator(button)',
     ),
 
     // bare calls

--- a/src/rules/no-raw-locators.test.ts
+++ b/src/rules/no-raw-locators.test.ts
@@ -46,15 +46,11 @@ runRuleTester('no-raw-locators', rule, {
       errors: [{ column: 77, endColumn: 100, line: 1, messageId }],
     },
     {
-      code: test(
-        'const button = page.locator(); page.locator(button)',
-      ),
+      code: test('const button = page.locator(); page.locator(button)'),
       errors: [{ column: 43, endColumn: 57, line: 1, messageId }],
     },
     {
-      code: test(
-        'let button = page.locator(); page.locator(button)',
-      ),
+      code: test('let button = page.locator(); page.locator(button)'),
       errors: [{ column: 41, endColumn: 55, line: 1, messageId }],
     },
     // Allowed

--- a/src/rules/no-raw-locators.ts
+++ b/src/rules/no-raw-locators.ts
@@ -20,7 +20,7 @@ export default createRule({
 
     return {
       CallExpression(node) {
-        if (node.callee.type !== 'MemberExpression') return
+        if (node.callee.type !== 'MemberExpression' || node.arguments[0]?.type === 'Identifier') return
         const method = getStringValue(node.callee.property)
         const arg = getStringValue(node.arguments[0])
         const isLocator = isPageMethod(node, 'locator') || method === 'locator'

--- a/src/rules/no-raw-locators.ts
+++ b/src/rules/no-raw-locators.ts
@@ -20,7 +20,11 @@ export default createRule({
 
     return {
       CallExpression(node) {
-        if (node.callee.type !== 'MemberExpression' || node.arguments[0]?.type === 'Identifier') return
+        if (
+          node.callee.type !== 'MemberExpression' ||
+          node.arguments[0]?.type === 'Identifier'
+        )
+          return
         const method = getStringValue(node.callee.property)
         const arg = getStringValue(node.arguments[0])
         const isLocator = isPageMethod(node, 'locator') || method === 'locator'


### PR DESCRIPTION
This PR updates the `no-raw-locators.ts` to allow properly defined locators to be passed as variables. I have added both positive and negative test cases.