### PR TITLE
fix(valid-test-tags): disallow extra properties in rule options and add to recommended

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -135,6 +135,7 @@ const sharedConfig = {
     'playwright/valid-describe-callback': 'error',
     'playwright/valid-expect': 'error',
     'playwright/valid-expect-in-promise': 'error',
+    'playwright/valid-test-tags': 'error',
     'playwright/valid-title': 'error',
   },
 } as const

--- a/src/rules/valid-test-tags.ts
+++ b/src/rules/valid-test-tags.ts
@@ -142,7 +142,11 @@ export default createRule({
             items: {
               oneOf: [
                 { type: 'string' },
-                { properties: { source: { type: 'string' } }, type: 'object' },
+                {
+                  additionalProperties: false,
+                  properties: { source: { type: 'string' } },
+                  type: 'object',
+                },
               ],
             },
             type: 'array',
@@ -151,7 +155,11 @@ export default createRule({
             items: {
               oneOf: [
                 { type: 'string' },
-                { properties: { source: { type: 'string' } }, type: 'object' },
+                {
+                  additionalProperties: false,
+                  properties: { source: { type: 'string' } },
+                  type: 'object',
+                },
               ],
             },
             type: 'array',


### PR DESCRIPTION
This PR disallows extra options properties in `valid-test-tags` rule options and actually adds it to the recommended config.