### PR TITLE
#383 - Fix JS prototype chain issue 

### DIFF
--- a/src/rules/prefer-web-first-assertions.test.ts
+++ b/src/rules/prefer-web-first-assertions.test.ts
@@ -1095,6 +1095,7 @@ runRuleTester('prefer-web-first-assertions', rule, {
     { code: test('let visible = await foo.isVisible()') },
     { code: test('const value = await bar["inputValue"]()') },
     { code: test('const isEditable = await baz[`isEditable`]()') },
+    { code: test('await expect(await locator.toString()).toBe("something")') },
     {
       code: javascript`
         import { expect } from '@playwright/test';

--- a/src/rules/prefer-web-first-assertions.ts
+++ b/src/rules/prefer-web-first-assertions.ts
@@ -85,7 +85,7 @@ export default createRule({
         // Playwright method must be supported
         const method = getStringValue(call.callee.property)
         const methodConfig = methods[method]
-        if (!methods.hasOwnProperty(method)) return
+        if (!Object.hasOwn(methods, method)) return
 
         // Change the matcher
         const notModifier = fnCall.modifiers.find(

--- a/src/rules/prefer-web-first-assertions.ts
+++ b/src/rules/prefer-web-first-assertions.ts
@@ -85,7 +85,7 @@ export default createRule({
         // Playwright method must be supported
         const method = getStringValue(call.callee.property)
         const methodConfig = methods[method]
-        if (!methodConfig) return
+        if (!methods.hasOwnProperty(method)) return
 
         // Change the matcher
         const notModifier = fnCall.modifiers.find(


### PR DESCRIPTION
This PR fixes #383 by using `methods.hasOwnProperty(method)` to check if the property exists on the object itself, not on the prototype chain.