### PR TITLE
#377 - Automatically support `test` and `expect` aliases with variable references 

### DIFF
--- a/src/rules/expect-expect.test.ts
+++ b/src/rules/expect-expect.test.ts
@@ -13,10 +13,19 @@ runRuleTester('expect-expect', rule, {
         stuff("should fail", () => {});
       `,
       errors: [{ messageId: 'noAssertions', type: 'Identifier' }],
+      name: 'Imported alias for test without assertions',
     },
     {
       code: 'test.skip("should fail", () => {});',
       errors: [{ messageId: 'noAssertions', type: 'MemberExpression' }],
+    },
+    {
+      code: javascript`
+        import { test as stuff } from '@playwright/test';
+        stuff.skip("should fail", () => {});
+      `,
+      errors: [{ messageId: 'noAssertions', type: 'MemberExpression' }],
+      name: 'Imported alias for test without assertions',
     },
     {
       code: javascript`
@@ -123,6 +132,27 @@ runRuleTester('expect-expect', rule, {
         stuff('works', () => { check(1).toBe(1); });
       `,
       name: 'Imported aliases for test and expect',
+    },
+    {
+      code: javascript`
+        import { test as stuff } from '@playwright/test';
+        stuff('works', () => { stuff.expect(1).toBe(1); });
+      `,
+      name: 'Aliased test with property expect',
+    },
+    {
+      code: javascript`
+        import { test as stuff, expect } from '@playwright/test';
+        stuff('works', () => { expect(1).toBe(1); });
+      `,
+      name: 'Aliased test with direct expect',
+    },
+    {
+      code: javascript`
+        import { test, expect as check } from '@playwright/test';
+        test('works', () => { check(1).toBe(1); });
+      `,
+      name: 'Direct test with aliased expect',
     },
     {
       code: 'it("should pass", () => expect(true).toBeDefined())',

--- a/src/rules/expect-expect.test.ts
+++ b/src/rules/expect-expect.test.ts
@@ -8,6 +8,13 @@ runRuleTester('expect-expect', rule, {
       errors: [{ messageId: 'noAssertions', type: 'Identifier' }],
     },
     {
+      code: javascript`
+        import { test as stuff } from '@playwright/test';
+        stuff("should fail", () => {});
+      `,
+      errors: [{ messageId: 'noAssertions', type: 'Identifier' }],
+    },
+    {
       code: 'test.skip("should fail", () => {});',
       errors: [{ messageId: 'noAssertions', type: 'MemberExpression' }],
     },
@@ -109,6 +116,13 @@ runRuleTester('expect-expect', rule, {
       `,
       name: 'Custom assert class method',
       options: [{ assertFunctionNames: ['assertCustomCondition'] }],
+    },
+    {
+      code: javascript`
+        import { test as stuff, expect as check } from '@playwright/test';
+        stuff('works', () => { check(1).toBe(1); });
+      `,
+      name: 'Imported aliases for test and expect',
     },
     {
       code: 'it("should pass", () => expect(true).toBeDefined())',

--- a/src/rules/no-commented-out-tests.test.ts
+++ b/src/rules/no-commented-out-tests.test.ts
@@ -87,6 +87,20 @@ runRuleTester('no-commented-out-tests', rule, {
         },
       },
     },
+    // Duplicate alias coming from both settings and import aliases should not
+    // create redundant entries in the regex and should still be detected.
+    {
+      code: javascript`
+        import { test as it } from '@playwright/test';
+        // it("foo", () => {});
+      `,
+      errors: [{ column: 1, line: 2, messageId }],
+      settings: {
+        playwright: {
+          globalAliases: { test: ['it'] },
+        },
+      },
+    },
   ],
   valid: [
     '// foo("bar", function () {})',

--- a/src/rules/no-commented-out-tests.test.ts
+++ b/src/rules/no-commented-out-tests.test.ts
@@ -143,5 +143,10 @@ runRuleTester('no-commented-out-tests', rule, {
         },
       },
     },
+    // Imported alias for test used properly and not commented
+    javascript`
+      import { test as stuff, expect as check } from '@playwright/test';
+      stuff('foo', () => { check(1).toBe(1); });
+    `,
   ],
 })

--- a/src/rules/no-commented-out-tests.ts
+++ b/src/rules/no-commented-out-tests.ts
@@ -1,10 +1,12 @@
 import { Rule } from 'eslint'
 import * as ESTree from 'estree'
 import { createRule } from '../utils/createRule.js'
+import { getImportedAliases } from '../utils/ast.js'
 
 function getTestNames(context: Rule.RuleContext) {
   const aliases = context.settings.playwright?.globalAliases?.test ?? []
-  return ['test', ...aliases]
+  const importAliases = getImportedAliases(context, 'test')
+  return ['test', ...aliases, ...importAliases]
 }
 
 function hasTests(context: Rule.RuleContext, node: ESTree.Comment) {

--- a/src/rules/no-commented-out-tests.ts
+++ b/src/rules/no-commented-out-tests.ts
@@ -6,7 +6,8 @@ import { getImportedAliases } from '../utils/ast.js'
 function getTestNames(context: Rule.RuleContext) {
   const aliases = context.settings.playwright?.globalAliases?.test ?? []
   const importAliases = getImportedAliases(context, 'test')
-  return ['test', ...aliases, ...importAliases]
+  const combined = ['test', ...aliases, ...importAliases]
+  return Array.from(new Set(combined))
 }
 
 function hasTests(context: Rule.RuleContext, node: ESTree.Comment) {

--- a/src/rules/no-standalone-expect.test.ts
+++ b/src/rules/no-standalone-expect.test.ts
@@ -10,6 +10,22 @@ runRuleTester('no-standalone-expect', rule, {
       errors: [{ column: 33, endColumn: 50, messageId }],
     },
     {
+      code: javascript`
+        import { expect as check } from '@playwright/test';
+        check(1).toBe(1);
+      `,
+      errors: [{ messageId }],
+      name: 'Imported expect alias outside of test',
+    },
+    {
+      code: javascript`
+        import { test as stuff, expect as check } from '@playwright/test';
+        stuff.describe('a test', () => { check(1).toBe(1); });
+      `,
+      errors: [{ messageId }],
+      name: 'Aliased expect inside aliased describe should be flagged',
+    },
+    {
       code: 'test.describe("a test", () => { expect.soft(1).toBe(1); });',
       errors: [{ column: 33, endColumn: 55, messageId }],
     },

--- a/src/utils/ast.test.ts
+++ b/src/utils/ast.test.ts
@@ -1,0 +1,39 @@
+import { describe, it, expect } from 'vitest'
+import type { Rule } from 'eslint'
+import { getImportedAliases } from './ast.js'
+
+describe('getImportedAliases', () => {
+  it('supports ImportSpecifier.imported as Literal', () => {
+    // Intentionally construct a nonstandard/synthetic AST: in valid JS parsed by
+    // standard ESTree parsers, `ImportSpecifier.imported` is an Identifier.
+    // Here we use a Literal ('test') to ensure `getImportedAliases` gracefully
+    // handles such shapes and still treats `import { test as it }` as aliasing.
+    const program: any = {
+      type: 'Program',
+      sourceType: 'module',
+      body: [
+        {
+          type: 'ImportDeclaration',
+          specifiers: [
+            {
+              type: 'ImportSpecifier',
+              imported: { type: 'Literal', value: 'test', raw: "'test'" },
+              local: { type: 'Identifier', name: 'it' },
+            },
+          ],
+          source: {
+            type: 'Literal',
+            value: '@playwright/test',
+            raw: "'@playwright/test'",
+          },
+        },
+      ],
+    }
+
+    const context = {
+      sourceCode: { ast: program },
+    } as unknown as Rule.RuleContext
+    const aliases = getImportedAliases(context, 'test')
+    expect(aliases).toEqual(['it'])
+  })
+})

--- a/src/utils/ast.ts
+++ b/src/utils/ast.ts
@@ -275,8 +275,14 @@ export function getImportedAliases(
 
     for (const spec of stmt.specifiers) {
       if (spec.type !== 'ImportSpecifier') continue
-
-      const imported = (spec.imported as ESTree.Identifier).name
+      if ((spec as any).importKind === 'type') continue
+      const importedNode = spec.imported as ESTree.Identifier | ESTree.Literal
+      const imported =
+        importedNode.type === 'Identifier'
+          ? importedNode.name
+          : typeof importedNode.value === 'string'
+          ? importedNode.value
+          : undefined
       if (imported !== importedName) continue
 
       const localName = spec.local.name

--- a/src/utils/ast.ts
+++ b/src/utils/ast.ts
@@ -266,7 +266,12 @@ export function getImportedAliases(
 
   for (const stmt of program.body) {
     if (stmt.type !== 'ImportDeclaration') continue
-    if (stmt.source.value !== '@playwright/test') continue
+    if (
+      !isStringLiteral(stmt.source) ||
+      stmt.source.value !== '@playwright/test'
+    )
+      continue
+    if ((stmt as any).importKind === 'type') continue
 
     for (const spec of stmt.specifiers) {
       if (spec.type !== 'ImportSpecifier') continue

--- a/src/utils/parseFnCall.test.ts
+++ b/src/utils/parseFnCall.test.ts
@@ -131,6 +131,58 @@ runRuleTester('nonexistent methods', rule, {
 runRuleTester('expect', rule, {
   invalid: [
     {
+      code: javascript`
+        import { expect as verify, expect as assertThat } from '@playwright/test';
+
+        verify(x).toBe(y);
+        assertThat(x).toBe(y);
+      `,
+      errors: [
+        {
+          column: 1,
+          data: expectedParsedFnCallResultData({
+            args: ['x'],
+            group: 'expect',
+            head: {
+              local: 'verify',
+              node: 'verify',
+              original: 'expect',
+            },
+            matcher: 'toBe',
+            matcherArgs: ['y'],
+            matcherName: 'toBe',
+            members: ['toBe'],
+            modifiers: [],
+            name: 'expect',
+            type: 'expect',
+          }),
+          line: 3,
+          messageId: 'details',
+        },
+        {
+          column: 1,
+          data: expectedParsedFnCallResultData({
+            args: ['x'],
+            group: 'expect',
+            head: {
+              local: 'assertThat',
+              node: 'assertThat',
+              original: 'expect',
+            },
+            matcher: 'toBe',
+            matcherArgs: ['y'],
+            matcherName: 'toBe',
+            members: ['toBe'],
+            modifiers: [],
+            name: 'expect',
+            type: 'expect',
+          }),
+          line: 4,
+          messageId: 'details',
+        },
+      ],
+    },
+    {
       code: 'expect(x).toBe(y);',
       errors: [
         {
@@ -321,6 +373,36 @@ runRuleTester('expect', rule, {
       ],
     },
     {
+      code: javascript`
+        import { expect as verify } from '@playwright/test';
+
+        verify(x).toBe(y);
+      `,
+      errors: [
+        {
+          column: 1,
+          data: expectedParsedFnCallResultData({
+            args: ['x'],
+            group: 'expect',
+            head: {
+              local: 'verify',
+              node: 'verify',
+              original: 'expect',
+            },
+            matcher: 'toBe',
+            matcherArgs: ['y'],
+            matcherName: 'toBe',
+            members: ['toBe'],
+            modifiers: [],
+            name: 'expect',
+            type: 'expect',
+          }),
+          line: 3,
+          messageId: 'details',
+        },
+      ],
+    },
+    {
       code: 'something(expect(x).not.toBe(y))',
       errors: [
         {
@@ -418,6 +500,48 @@ runRuleTester('expect', rule, {
 
 runRuleTester('test', rule, {
   invalid: [
+    {
+      code: javascript`
+        import { test as it, test as spec } from '@playwright/test';
+
+        it('a test', () => {});
+        spec('another test', () => {});
+      `,
+      errors: [
+        {
+          column: 1,
+          data: expectedParsedFnCallResultData({
+            group: 'test',
+            head: {
+              local: 'it',
+              node: 'it',
+              original: 'test',
+            },
+            members: [],
+            name: 'test',
+            type: 'test',
+          }),
+          line: 3,
+          messageId: 'details',
+        },
+        {
+          column: 1,
+          data: expectedParsedFnCallResultData({
+            group: 'test',
+            head: {
+              local: 'spec',
+              node: 'spec',
+              original: 'test',
+            },
+            members: [],
+            name: 'test',
+            type: 'test',
+          }),
+          line: 4,
+          messageId: 'details',
+        },
+      ],
+    },
     {
       code: 'test("a test", () => {});',
       errors: [
@@ -801,6 +925,31 @@ runRuleTester('test', rule, {
             type: 'config',
           }),
           line: 1,
+          messageId: 'details',
+        },
+      ],
+    },
+    {
+      code: javascript`
+        import { test as it } from '@playwright/test';
+
+        it('a test', () => {});
+      `,
+      errors: [
+        {
+          column: 1,
+          data: expectedParsedFnCallResultData({
+            group: 'test',
+            head: {
+              local: 'it',
+              node: 'it',
+              original: 'test',
+            },
+            members: [],
+            name: 'test',
+            type: 'test',
+          }),
+          line: 3,
           messageId: 'details',
         },
       ],

--- a/src/utils/parseFnCall.test.ts
+++ b/src/utils/parseFnCall.test.ts
@@ -183,6 +183,59 @@ runRuleTester('expect', rule, {
       ],
     },
     {
+      code: javascript`
+        import { expect as verify } from '@playwright/test';
+        import { expect as assertThat } from '@playwright/test';
+
+        verify(x).toBe(y);
+        assertThat(x).toBe(y);
+      `,
+      errors: [
+        {
+          column: 1,
+          data: expectedParsedFnCallResultData({
+            args: ['x'],
+            group: 'expect',
+            head: {
+              local: 'verify',
+              node: 'verify',
+              original: 'expect',
+            },
+            matcher: 'toBe',
+            matcherArgs: ['y'],
+            matcherName: 'toBe',
+            members: ['toBe'],
+            modifiers: [],
+            name: 'expect',
+            type: 'expect',
+          }),
+          line: 4,
+          messageId: 'details',
+        },
+        {
+          column: 1,
+          data: expectedParsedFnCallResultData({
+            args: ['x'],
+            group: 'expect',
+            head: {
+              local: 'assertThat',
+              node: 'assertThat',
+              original: 'expect',
+            },
+            matcher: 'toBe',
+            matcherArgs: ['y'],
+            matcherName: 'toBe',
+            members: ['toBe'],
+            modifiers: [],
+            name: 'expect',
+            type: 'expect',
+          }),
+          line: 5,
+          messageId: 'details',
+        },
+      ],
+    },
+    {
       code: 'expect(x).toBe(y);',
       errors: [
         {
@@ -403,6 +456,36 @@ runRuleTester('expect', rule, {
       ],
     },
     {
+      code: javascript`
+        import { expect as verify } from '@playwright/test';
+
+        verify(x).not.toBe(y);
+      `,
+      errors: [
+        {
+          column: 1,
+          data: expectedParsedFnCallResultData({
+            args: ['x'],
+            group: 'expect',
+            head: {
+              local: 'verify',
+              node: 'verify',
+              original: 'expect',
+            },
+            matcher: 'toBe',
+            matcherArgs: ['y'],
+            matcherName: 'toBe',
+            members: ['not', 'toBe'],
+            modifiers: ['not'],
+            name: 'expect',
+            type: 'expect',
+          }),
+          line: 3,
+          messageId: 'details',
+        },
+      ],
+    },
+    {
       code: 'something(expect(x).not.toBe(y))',
       errors: [
         {
@@ -538,6 +621,49 @@ runRuleTester('test', rule, {
             type: 'test',
           }),
           line: 4,
+          messageId: 'details',
+        },
+      ],
+    },
+    {
+      code: javascript`
+        import { test as it } from '@playwright/test';
+        import { test as check } from '@playwright/test';
+
+        it('a test', () => {});
+        check('another test', () => {});
+      `,
+      errors: [
+        {
+          column: 1,
+          data: expectedParsedFnCallResultData({
+            group: 'test',
+            head: {
+              local: 'it',
+              node: 'it',
+              original: 'test',
+            },
+            members: [],
+            name: 'test',
+            type: 'test',
+          }),
+          line: 4,
+          messageId: 'details',
+        },
+        {
+          column: 1,
+          data: expectedParsedFnCallResultData({
+            group: 'test',
+            head: {
+              local: 'check',
+              node: 'check',
+              original: 'test',
+            },
+            members: [],
+            name: 'test',
+            type: 'test',
+          }),
+          line: 5,
           messageId: 'details',
         },
       ],
@@ -1311,6 +1437,35 @@ runTSRuleTester('typescript', rule, {
 
         expect.assertions();
         expect.anything();
+      `,
+    },
+    // Type-only imports/specifiers should NOT create runtime aliases
+    {
+      code: typescript`
+        import type { test as it } from '@playwright/test';
+
+        it('is not detected as Playwright test', () => {});
+      `,
+    },
+    {
+      code: typescript`
+        import { type test as it } from '@playwright/test';
+
+        it('is not detected as Playwright test', () => {});
+      `,
+    },
+    {
+      code: typescript`
+        import type { expect as verify } from '@playwright/test';
+
+        verify(x).toBe(y);
+      `,
+    },
+    {
+      code: typescript`
+        import { type expect as verify } from '@playwright/test';
+
+        verify(x).toBe(y);
       `,
     },
   ],


### PR DESCRIPTION
The list of changes in this PR:

- Add new function `getImportedAliases` to the `src/utils/ast.ts` that gets and resolves importedAliases. The function is heavy guarded against various runtime erros.
- Extended `resolveToPlaywrightFn` to use `getImportedAliases`.
- Added various tests for `test` and `expect` aliases.
- Added tests for `src/utils/ast.ts`.