### PR TITLE
docs: Use ESLint `defineConfig` and `extends`

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,19 +38,19 @@ file patterns.
 (**eslint.config.js**)
 
 ```javascript
+import { defineConfig } from '@eslint/config'
 import playwright from 'eslint-plugin-playwright'
 
-export default [
+export default defineConfig([
   {
-    ...playwright.configs['flat/recommended'],
     files: ['tests/**'],
+    extends: [playwright.configs['flat/recommended']],
     rules: {
-      ...playwright.configs['flat/recommended'].rules,
       // Customize Playwright rules
       // ...
     },
   },
-]
+])
 ```
 
 [Legacy config](https://eslint.org/docs/latest/use/configure/configuration-files)


### PR DESCRIPTION
Since [March of this year](https://eslint.org/blog/2025/03/flat-config-extends-define-config-global-ignores/#bringing-back-extends), ESLint supports and [recommends](https://eslint.org/docs/latest/use/configure/configuration-files#extending-configurations) using `defineConfig` and `extends` for flat configurations (instead of having to manually spread the pieces of the configuration).