### PR TITLE
fix(no-standalone-expect): Allow expect in fixture methods

### DIFF
--- a/src/rules/no-standalone-expect.test.ts
+++ b/src/rules/no-standalone-expect.test.ts
@@ -128,5 +128,50 @@ runRuleTester('no-standalone-expect', rule, {
         },
       },
     },
+    // Fixtures
+    {
+      code: javascript`
+        import { test as base, expect } from '@playwright/test';
+
+        export const test = base.extend({
+          clipboardContents: async ({ page }, use) => {
+            await expect(page).toHaveURL('example.com');
+            const text = await page.evaluate(() => navigator.clipboard.readText());
+            await expect(page).toHaveURL('example.com');
+            await use(text);
+          }
+        });
+
+        export { expect } from '@playwright/test';
+      `,
+      name: 'Allows expect in fixture definitions',
+    },
+    {
+      code: javascript`
+        import { test, expect } from '@playwright/test';
+
+        const customTest = test.extend({
+          myFixture: async ({ page }, use) => {
+            await expect(page).toBeDefined();
+            await use(page);
+          }
+        });
+      `,
+      name: 'Allows expect in test.extend fixtures',
+    },
+    {
+      code: javascript`
+        import { test as base } from '@playwright/test';
+
+        const test = base.extend({
+          fixture: async ({}, use) => {
+            const value = await Promise.resolve(42);
+            expect(value).toBe(42);
+            await use(value);
+          }
+        });
+      `,
+      name: 'Allows expect in fixture without await',
+    },
   ],
 })


### PR DESCRIPTION
Fixes #400

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Permits `expect` inside Playwright fixture definitions by tracking `.extend` calls as a new `fixture` context and adds corresponding tests.
> 
> - **Rule (`src/rules/no-standalone-expect.ts`)**:
>   - Add `fixture` block type; treat `.extend` member calls as fixture context using `isPropertyAccessor`.
>   - Allow `expect` within `fixture` blocks; keep existing restrictions elsewhere.
>   - Import and use `isPropertyAccessor`; update call stack enter/exit logic for `.extend`.
> - **Tests (`src/rules/no-standalone-expect.test.ts`)**:
>   - Add valid cases allowing `expect` in fixture definitions (`base.extend`, `test.extend`) and a case without `await`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0b0a96f9896c9e3ef7a0334b0ddaee799f043932. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->