### PR TITLE
docs(valid-test-tags): add missing url and category

### DIFF
--- a/src/rules/valid-test-tags.ts
+++ b/src/rules/valid-test-tags.ts
@@ -133,8 +133,10 @@ export default createRule({
   },
   meta: {
     docs: {
+      category: 'Possible Errors',
       description: 'Enforce valid tag format in Playwright test blocks and titles',
       recommended: true,
+      url: 'https://github.com/mskelton/eslint-plugin-playwright/tree/main/docs/rules/valid-test-tags.md',
     },
     messages: {
       disallowedTag: 'Tag "{{tag}}" is not allowed',


### PR DESCRIPTION
The `valid-test-tags` rule was missing a `meta.docs.url` and `meta.docs.category`, so I added them to match other rules' metadata.