### PR TITLE
Handle promise chains within missing-playwright-await

### DIFF
--- a/src/rules/missing-playwright-await.test.ts
+++ b/src/rules/missing-playwright-await.test.ts
@@ -424,6 +424,7 @@ runRuleTester('missing-playwright-await', rule, {
     { code: test('await page.waitForPopup()') },
     { code: test('await page.waitForWebSocket("wss://example.com")') },
     { code: test('return page.waitForResponse("https://example.com")') },
+    { code: test('await page.waitForResponse("https://example.com").then(res => res.json())') },
     { code: test('const fn = () => page.waitForResponse("https://example.com")') },
     {
       code: test(`

--- a/src/rules/missing-playwright-await.ts
+++ b/src/rules/missing-playwright-await.ts
@@ -115,6 +115,15 @@ export default createRule({
       // check any further.
       if (validTypes.has(parent.type)) return true
 
+      // If part of a promise chain, walk the chain up.
+      if (
+        parent.type === 'MemberExpression' &&
+        isIdentifier(parent.property, /^(then|catch|finally)$/) &&
+        parent.parent?.type === 'CallExpression'
+      ) {
+        return checkValidity(parent.parent, visited)
+      }
+
       // If the parent is an array, we need to check the grandparent to see if
       // it's a Promise.all, or a variable.
       if (parent.type === 'ArrayExpression') {


### PR DESCRIPTION
I noticed that the changes to support #199 have false positives with promise chains such as the following:

```ts
const response = await page.waitForResponse('https://example.com/')
  .then(res => res.json());
```

Here's an attempt at a fix.