### PR TITLE
fix(missing-playwright-await): Fix false positive when not assigning awaited variable

### DIFF
--- a/src/rules/missing-playwright-await.test.ts
+++ b/src/rules/missing-playwright-await.test.ts
@@ -1067,6 +1067,13 @@ runRuleTester('missing-playwright-await', rule, {
     {
       code: dedent(
         test(`
+          await expect(page.waitForEvent('download')).resolves.toBeTruthy()
+        `),
+      ),
+    },
+    {
+      code: dedent(
+        test(`
           const requestPromise = page.waitForRequest("https://example.com/resource")
           await expect(requestPromise).resolves.toBeTruthy()
         `),

--- a/src/rules/missing-playwright-await.ts
+++ b/src/rules/missing-playwright-await.ts
@@ -330,7 +330,10 @@ export default createRule({
       if (parent.type === 'MemberExpression' && parent.object === node) {
         return checkValidity(parent, visited)
       }
-      if (parent.type === 'CallExpression' && parent.callee === node) {
+      if (
+        parent.type === 'CallExpression' &&
+        (parent.callee === node || isIdentifier(parent.callee, 'expect'))
+      ) {
         return checkValidity(parent, visited)
       }
 


### PR DESCRIPTION
Currently, code like the following triggers a `missing-playwright-await` false positive (see test that I've changed):

```ts
await expect(page.waitForEvent('download')).resolves.toBeTruthy()
```

I'm not super experienced with ESLint plugins or ESTree, so maybe there's a better way to make this change, but this does seem to fix it!