### PR TITLE
Handle optional chaining in missing-playwright-await

### DIFF
--- a/src/rules/missing-playwright-await.test.ts
+++ b/src/rules/missing-playwright-await.test.ts
@@ -453,6 +453,11 @@ runRuleTester('missing-playwright-await', rule, {
       options: [{ includePageLocatorMethods: true }],
     },
     {
+      code: test('page?.unrouteAll()'),
+      errors: [{ column: 28, messageId: 'missingAwait' }],
+      options: [{ includePageLocatorMethods: true }],
+    },
+    {
       code: test('page.screenshot()'),
       errors: [{ column: 28, messageId: 'missingAwait' }],
       options: [{ includePageLocatorMethods: true }],
@@ -1222,6 +1227,10 @@ runRuleTester('missing-playwright-await', rule, {
     },
     {
       code: test('await bar.fill("sel", "val")'),
+      options: [{ includePageLocatorMethods: true }],
+    },
+    {
+      code: test('await page?.unrouteAll()'),
       options: [{ includePageLocatorMethods: true }],
     },
     {

--- a/src/rules/missing-playwright-await.ts
+++ b/src/rules/missing-playwright-await.ts
@@ -300,6 +300,11 @@ export default createRule({
         return checkValidity(parent, visited)
       }
 
+      // Optional chaining wraps calls in ChainExpression, e.g. await page?.unrouteAll()
+      if (parent.type === 'ChainExpression') {
+        return checkValidity(parent, visited)
+      }
+
       // Inside a spread (e.g. ...[promise]); walk up
       if (parent.type === 'SpreadElement') {
         return checkValidity(parent, visited)


### PR DESCRIPTION
`missing-playwright-await` could report awaited optional-chained Playwright calls, such as `await page?.unrouteAll()`.

This treats the `ChainExpression` wrapper as transparent while walking the awaited call. I checked the repro red-to-green and ran the full test/CI checks with 3,309 tests passing.

Fixes #467