### PR TITLE
add explanation for `prefer-locator`

### DIFF
--- a/docs/rules/prefer-locator.md
+++ b/docs/rules/prefer-locator.md
@@ -1,7 +1,8 @@
 # Suggest using `page.locator()` (`prefer-locator`)
 
 Suggest using locators and their associated methods instead of page methods for
-performing actions.
+performing actions. `Page` methods that have `Locator` equivalents [are discouraged
+in Playwright](https://playwright.dev/docs/api/class-page#page-click).
 
 ## Rule details
 


### PR DESCRIPTION
it wasn't clear why `Page` methods aren't allowed, so i added a link to the playwright docs where it says they are discouraged.

honestly they don't really explain why it's discouraged either, but at least linking to their docs makes it clear that the recommendation comes from the playwright maintainers themselves